### PR TITLE
add joda time support to generator

### DIFF
--- a/core/mybatis-generator-core/pom.xml
+++ b/core/mybatis-generator-core/pom.xml
@@ -217,6 +217,11 @@
       <artifactId>hsqldb</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>joda-time</groupId>
+      <artifactId>joda-time</artifactId>
+      <version>2.3</version>
+    </dependency>
   </dependencies>
 
   <scm>

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/JavaTypeResolver.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/JavaTypeResolver.java
@@ -84,4 +84,9 @@ public interface JavaTypeResolver {
      *         warning unless the column is ignored or otherwise overridden
      */
     String calculateJdbcTypeName(IntrospectedColumn introspectedColumn);
+
+    /**
+     * Populates the type map, this depends on configuration properties so it can't be done in the constructor.
+     */
+    public void populateTypeMap();
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/config/PropertyRegistry.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/config/PropertyRegistry.java
@@ -62,6 +62,7 @@ public class PropertyRegistry {
     public static final String DAO_METHOD_NAME_CALCULATOR = "methodNameCalculator"; //$NON-NLS-1$
 
     public static final String TYPE_RESOLVER_FORCE_BIG_DECIMALS = "forceBigDecimals"; //$NON-NLS-1$
+    public static final String TYPE_RESOLVER_USE_JODA_TIME = "useJodaTime"; //$NON-NLS-1$
 
     public static final String MODEL_GENERATOR_TRIM_STRINGS = "trimStrings"; //$NON-NLS-1$
 

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/internal/ObjectFactory.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/internal/ObjectFactory.java
@@ -209,6 +209,7 @@ public class ObjectFactory {
 
         if (config != null) {
             answer.addConfigurationProperties(config.getProperties());
+            answer.populateTypeMap();
         }
 
         answer.setContext(context);

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/internal/types/JavaTypeResolverDefaultImpl.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/internal/types/JavaTypeResolverDefaultImpl.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import org.joda.time.DateTime;
 import org.mybatis.generator.api.IntrospectedColumn;
 import org.mybatis.generator.api.JavaTypeResolver;
 import org.mybatis.generator.api.dom.java.FullyQualifiedJavaType;
@@ -44,13 +45,31 @@ public class JavaTypeResolverDefaultImpl implements JavaTypeResolver {
 
     protected boolean forceBigDecimals;
 
+    protected String dateTypeName;
+
     protected Map<Integer, JdbcTypeInformation> typeMap;
     
     public JavaTypeResolverDefaultImpl() {
         super();
         properties = new Properties();
         typeMap = new HashMap<Integer, JdbcTypeInformation>();
+    }
 
+    public void addConfigurationProperties(Properties properties) {
+        this.properties.putAll(properties);
+        forceBigDecimals = StringUtility
+                .isTrue(properties
+                        .getProperty(PropertyRegistry.TYPE_RESOLVER_FORCE_BIG_DECIMALS));
+        if(StringUtility
+                .isTrue(properties
+                        .getProperty(PropertyRegistry.TYPE_RESOLVER_USE_JODA_TIME))) {
+            dateTypeName = DateTime.class.getName();
+        } else {
+            dateTypeName = Date.class.getName();
+        }
+    }
+
+    public void populateTypeMap() {
         typeMap.put(Types.ARRAY, new JdbcTypeInformation("ARRAY", //$NON-NLS-1$
                 new FullyQualifiedJavaType(Object.class.getName())));
         typeMap.put(Types.BIGINT, new JdbcTypeInformation("BIGINT", //$NON-NLS-1$
@@ -70,7 +89,7 @@ public class JavaTypeResolverDefaultImpl implements JavaTypeResolver {
         typeMap.put(Types.DATALINK, new JdbcTypeInformation("DATALINK", //$NON-NLS-1$
                 new FullyQualifiedJavaType(Object.class.getName())));
         typeMap.put(Types.DATE, new JdbcTypeInformation("DATE", //$NON-NLS-1$
-                new FullyQualifiedJavaType(Date.class.getName())));
+                new FullyQualifiedJavaType(dateTypeName)));
         typeMap.put(Types.DISTINCT, new JdbcTypeInformation("DISTINCT", //$NON-NLS-1$
                 new FullyQualifiedJavaType(Object.class.getName())));
         typeMap.put(Types.DOUBLE, new JdbcTypeInformation("DOUBLE", //$NON-NLS-1$
@@ -107,23 +126,15 @@ public class JavaTypeResolverDefaultImpl implements JavaTypeResolver {
         typeMap.put(Types.STRUCT, new JdbcTypeInformation("STRUCT", //$NON-NLS-1$
                 new FullyQualifiedJavaType(Object.class.getName())));
         typeMap.put(Types.TIME, new JdbcTypeInformation("TIME", //$NON-NLS-1$
-                new FullyQualifiedJavaType(Date.class.getName())));
+                new FullyQualifiedJavaType(dateTypeName)));
         typeMap.put(Types.TIMESTAMP, new JdbcTypeInformation("TIMESTAMP", //$NON-NLS-1$
-                new FullyQualifiedJavaType(Date.class.getName())));
+                new FullyQualifiedJavaType(dateTypeName)));
         typeMap.put(Types.TINYINT, new JdbcTypeInformation("TINYINT", //$NON-NLS-1$
                 new FullyQualifiedJavaType(Byte.class.getName())));
         typeMap.put(Types.VARBINARY, new JdbcTypeInformation("VARBINARY", //$NON-NLS-1$
                 new FullyQualifiedJavaType("byte[]"))); //$NON-NLS-1$
         typeMap.put(Types.VARCHAR, new JdbcTypeInformation("VARCHAR", //$NON-NLS-1$
                 new FullyQualifiedJavaType(String.class.getName())));
-        
-    }
-
-    public void addConfigurationProperties(Properties properties) {
-        this.properties.putAll(properties);
-        forceBigDecimals = StringUtility
-                .isTrue(properties
-                        .getProperty(PropertyRegistry.TYPE_RESOLVER_FORCE_BIG_DECIMALS));
     }
 
     public FullyQualifiedJavaType calculateJavaType(


### PR DESCRIPTION
Does this look like a reasonable way to add support for joda time to the generator? Tests are currently failing:

[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.0:compile (default-compile) on project mybatis-generator-systests-mybatis3: Compilation failure: Compilation failure:
[ERROR] /home/ben/Documents/new_src/generator/core/mybatis-generator-systests-mybatis3/target/generated-sources/mybatis-generator/mbg/test/mb3/generated/annotated/miscellaneous/model/MyObject.java:[127,19] getLastname() in mbg.test.mb3.generated.annotated.miscellaneous.model.MyObject cannot override getLastname() in mbg.test.common.BaseClass
[ERROR] overridden method is final
[ERROR] /home/ben/Documents/new_src/generator/core/mybatis-generator-systests-mybatis3/target/generated-sources/mybatis-generator/mbg/test/mb3/generated/mixed/miscellaneous/model/MyObject.java:[127,19] getLastname() in mbg.test.mb3.generated.mixed.miscellaneous.model.MyObject cannot override getLastname() in mbg.test.common.BaseClass
[ERROR] overridden method is final
[ERROR] /home/ben/Documents/new_src/generator/core/mybatis-generator-systests-mybatis3/target/generated-sources/mybatis-generator/mbg/test/mb3/generated/miscellaneous/model/MyObject.java:[127,19] getLastname() in mbg.test.mb3.generated.miscellaneous.model.MyObject cannot override getLastname() in mbg.test.common.BaseClass
[ERROR] overridden method is final
