### PR TITLE
The full table name has duplicate separator when catalog is not empty

### DIFF
--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/internal/util/StringUtility.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/internal/util/StringUtility.java
@@ -46,10 +46,6 @@ public class StringUtility {
         if (stringHasValue(schema)) {
             sb.append(schema);
             sb.append(separator);
-        } else {
-            if (sb.length() > 0) {
-                sb.append(separator);
-            }
         }
 
         sb.append(tableName);


### PR DESCRIPTION
If using table catalog, the full table name in generated XML mapper files has duplicate separator.