### PR TITLE
Improve the logic for determining whether to use the type short name.

### DIFF
--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/JavaElement.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/JavaElement.java
@@ -212,7 +212,7 @@ public abstract class JavaElement {
             if(!fqjt.isExplicitlyImported() 
                     || compilationUnit == null 
                     || fqjt.getPackageName().equals(compilationUnit.getType().getPackageName()) 
-                    || compilationUnit.getImportedTypes().contains(fqjt)) {
+                    || compilationUnit.getImportedTypes().contains(new FullyQualifiedJavaType(fqjt.getFullyQualifiedNameWithoutTypeParameters()))) {
                 sb.append(fqjt.getShortName());
             } else {
                 sb.append(fqjt.getFullyQualifiedName());


### PR DESCRIPTION
This was failing for generic types in the sense that generic types were
being written fully qualified even if they were in the import list.

This is related to the changes made for #63 