### PR TITLE
Fix custom TypeHandler bug

### DIFF
--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/xmlmapper/elements/ExampleWhereClauseElementGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/xmlmapper/elements/ExampleWhereClauseElementGenerator.java
@@ -116,6 +116,11 @@ public class ExampleWhereClauseElementGenerator extends
             typeHandled = true;
 
             sb.setLength(0);
+
+            // javaType
+            sb.append(",javaType=");
+            sb.append(introspectedColumn.getFullyQualifiedJavaType().getFullyQualifiedName());
+
             sb.append(",typeHandler="); //$NON-NLS-1$
             sb.append(introspectedColumn.getTypeHandler());
             typeHandlerString = sb.toString();


### PR DESCRIPTION
When developer use the "columnOverride typeHandler", the generator should add a "javaType" in criteria statments.