### PR TITLE
Reset cached information at the start of generation runs

### DIFF
--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/MyBatisGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/MyBatisGenerator.java
@@ -29,6 +29,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.mybatis.generator.codegen.RootClassInfo;
 import org.mybatis.generator.config.Configuration;
 import org.mybatis.generator.config.Context;
 import org.mybatis.generator.config.MergeConstants;
@@ -223,6 +224,8 @@ public class MyBatisGenerator {
 
         generatedJavaFiles.clear();
         generatedXmlFiles.clear();
+        ObjectFactory.reset();
+        RootClassInfo.reset();
 
         // calculate the contexts to run
         List<Context> contextsToRun;

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/RootClassInfo.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/RootClassInfo.java
@@ -54,6 +54,17 @@ public class RootClassInfo {
         return classInfo;
     }
 
+    /**
+     * Clears the internal map containing root class info.  This method should be called at the beginning of
+     * a generation run to clear the cached root class info in case there has been a change.
+     * For example, when using the eclipse launcher, the cache would be kept until eclipse
+     * was restarted.
+     * 
+     */
+    public static void reset() {
+        rootClassInfoMap.clear();
+    }
+
     private PropertyDescriptor[] propertyDescriptors;
     private String className;
     private List<String> warnings;

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/internal/ObjectFactory.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/internal/ObjectFactory.java
@@ -63,12 +63,24 @@ public class ObjectFactory {
     	externalClassLoaders = new ArrayList<ClassLoader>();
         resourceClassLoaders = new ArrayList<ClassLoader>();
     }
-
+    
     /**
      * Utility class. No instances allowed
      */
     private ObjectFactory() {
         super();
+    }
+
+    /**
+     * Clears the class loaders.  This method should be called at the beginning of
+     * a generation run so that and change to the classloading configuration
+     * will be reflected.  For example, if the eclipse launcher changes configuration
+     * it might not be updated if eclipse hasn't been restarted.
+     * 
+     */
+    public static void reset() {
+        externalClassLoaders.clear();
+        resourceClassLoaders.clear();
     }
 
     /**


### PR DESCRIPTION
The eclipse launcher runs in the same JRE, so these items aren't reset
until eclipse ends.  This can lead to weird results when classpath or
objects are changing.