### PR TITLE
Build Improvements in Eclipse

### DIFF
--- a/core/mybatis-generator-systests-ibatis2-java2/pom.xml
+++ b/core/mybatis-generator-systests-ibatis2-java2/pom.xml
@@ -130,4 +130,37 @@
     </dependency>
   </dependencies>
   <description>Tests for the iBatis code generator in a Java 2 environment (no generics)</description>
+  
+  <profiles>
+    <profile>
+     <id>eclipse</id>
+      <activation>
+        <property>
+          <name>m2e.version</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>add-generated-source</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>add-source</goal>
+                </goals>
+                <configuration>
+                  <sources>
+                    <source>target/generated-sources/mybatis-generator</source>
+                  </sources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/core/mybatis-generator-systests-ibatis2-java5/pom.xml
+++ b/core/mybatis-generator-systests-ibatis2-java5/pom.xml
@@ -125,4 +125,36 @@
     </dependency>
   </dependencies>
   <description>Tests for the iBatis code generator in a Java 5 environment (with generics)</description>
+  <profiles>
+    <profile>
+     <id>eclipse</id>
+      <activation>
+        <property>
+          <name>m2e.version</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>add-generated-source</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>add-source</goal>
+                </goals>
+                <configuration>
+                  <sources>
+                    <source>target/generated-sources/mybatis-generator</source>
+                  </sources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/core/mybatis-generator-systests-mybatis3/pom.xml
+++ b/core/mybatis-generator-systests-mybatis3/pom.xml
@@ -114,4 +114,36 @@
     </dependency>
   </dependencies>
   <description>Tests for the MyBatis3 code generator.</description>
+  <profiles>
+    <profile>
+     <id>eclipse</id>
+      <activation>
+        <property>
+          <name>m2e.version</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>add-generated-source</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>add-source</goal>
+                </goals>
+                <configuration>
+                  <sources>
+                    <source>target/generated-sources/mybatis-generator</source>
+                  </sources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
Use build helper to add the generated source directory.  Just makes eclipse initial setup a bit easier.