### PR TITLE
Add DomainObjectRenamingRule to rename the domain object name.

### DIFF
--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/IntrospectedTable.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/IntrospectedTable.java
@@ -18,6 +18,7 @@ package org.mybatis.generator.api;
 import static org.mybatis.generator.internal.util.StringUtility.isTrue;
 import static org.mybatis.generator.internal.util.StringUtility.stringHasValue;
 
+import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -1339,7 +1340,7 @@ public abstract class IntrospectedTable {
         sb.append(calculateJavaClientInterfacePackage());
         sb.append('.');
         if (stringHasValue(tableConfiguration.getMapperName())) {
-            sb.append(tableConfiguration.getMapperName());
+            sb.append(MessageFormat.format(tableConfiguration.getMapperName(), fullyQualifiedTable.getDomainObjectName()));
         } else {
             sb.append(fullyQualifiedTable.getDomainObjectName());
             sb.append("Mapper"); //$NON-NLS-1$
@@ -1350,7 +1351,7 @@ public abstract class IntrospectedTable {
         sb.append(calculateJavaClientInterfacePackage());
         sb.append('.');
         if (stringHasValue(tableConfiguration.getSqlProviderName())) {
-            sb.append(tableConfiguration.getSqlProviderName());
+            sb.append(MessageFormat.format(tableConfiguration.getSqlProviderName(), fullyQualifiedTable.getDomainObjectName()));
         } else {
             sb.append(fullyQualifiedTable.getDomainObjectName());
             sb.append("SqlProvider"); //$NON-NLS-1$

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/config/DomainObjectRenamingRule.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/config/DomainObjectRenamingRule.java
@@ -1,0 +1,93 @@
+/**
+ *    Copyright 2006-2016 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.generator.config;
+
+import org.mybatis.generator.api.dom.xml.Attribute;
+import org.mybatis.generator.api.dom.xml.XmlElement;
+
+import java.util.List;
+
+import static org.mybatis.generator.internal.util.StringUtility.stringHasValue;
+import static org.mybatis.generator.internal.util.messages.Messages.getString;
+
+/**
+ * This class is used to specify a renaming rule for table's domain object name.
+ * If domainObjectName is not configured, we'll build the domain object named
+ * based on the tableName or runtimeTableName. And then we use the domain object
+ * renameing rule to generate the final domain object name.
+ * 
+ * For example, if some tables are named:
+ * 
+ * <ul>
+ * <li>SYS_USER</li>
+ * <li>SYS_ROLE</li>
+ * <li>SYS_FUNCTIONS</li>
+ * </ul>
+ * 
+ * it might be annoying to have the generated domain name all containing the SYS
+ * prefix. This class can be used to remove the prefix by specifying
+ * 
+ * <ul>
+ * <li>searchString = "^SYS"</li>
+ * <li>replaceString=""</li>
+ * </ul>
+ * 
+ * Note that internally, the generator uses the
+ * <code>java.util.regex.Matcher.replaceAll</code> method for this function. See
+ * the documentation of that method for example of the regular expression
+ * language used in Java.
+ * 
+ * @author liuzh
+ * 
+ */
+public class DomainObjectRenamingRule {
+    private String searchString;
+    private String replaceString;
+
+    public String getReplaceString() {
+        return replaceString;
+    }
+
+    public void setReplaceString(String replaceString) {
+        this.replaceString = replaceString;
+    }
+
+    public String getSearchString() {
+        return searchString;
+    }
+
+    public void setSearchString(String searchString) {
+        this.searchString = searchString;
+    }
+
+    public void validate(List<String> errors, String tableName) {
+        if (!stringHasValue(searchString)) {
+            errors.add(getString("ValidationError.28", tableName)); //$NON-NLS-1$
+        }
+    }
+
+    public XmlElement toXmlElement() {
+        XmlElement xmlElement = new XmlElement("domainRenamingRule"); //$NON-NLS-1$
+        xmlElement.addAttribute(new Attribute("searchString", searchString)); //$NON-NLS-1$
+
+        if (replaceString != null) {
+            xmlElement.addAttribute(new Attribute(
+                    "replaceString", replaceString)); //$NON-NLS-1$
+        }
+
+        return xmlElement;
+    }
+}

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/config/TableConfiguration.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/config/TableConfiguration.java
@@ -104,9 +104,12 @@ public class TableConfiguration extends PropertyHolder {
     /** The delimit identifiers. */
     private boolean delimitIdentifiers;
 
+    /** The domain object renaming rule. */
+    private DomainObjectRenamingRule domainObjectRenamingRule;
+
     /** The column renaming rule. */
     private ColumnRenamingRule columnRenamingRule;
-    
+
     /** The is all column delimiting enabled. */
     private boolean isAllColumnDelimitingEnabled;
     
@@ -708,6 +711,10 @@ public class TableConfiguration extends PropertyHolder {
             xmlElement.addElement(generatedKey.toXmlElement());
         }
 
+        if (domainObjectRenamingRule != null) {
+            xmlElement.addElement(domainObjectRenamingRule.toXmlElement());
+        }
+
         if (columnRenamingRule != null) {
             xmlElement.addElement(columnRenamingRule.toXmlElement());
         }
@@ -834,6 +841,10 @@ public class TableConfiguration extends PropertyHolder {
             }
         }
 
+        if (domainObjectRenamingRule != null) {
+            domainObjectRenamingRule.validate(errors, fqTableName);
+        }
+
         if (columnRenamingRule != null) {
             columnRenamingRule.validate(errors, fqTableName);
         }
@@ -849,6 +860,25 @@ public class TableConfiguration extends PropertyHolder {
         for (IgnoredColumnPattern ignoredColumnPattern : ignoredColumnPatterns) {
             ignoredColumnPattern.validate(errors, fqTableName);
         }
+    }
+
+    /**
+     * Gets the domain object renaming rule.
+     *
+     * @return the domain object renaming rule
+     */
+    public DomainObjectRenamingRule getDomainObjectRenamingRule() {
+        return domainObjectRenamingRule;
+    }
+
+    /**
+     * Sets the domain object renaming rule.
+     *
+     * @param domainObjectRenamingRule
+     *            the new domain object renaming rule
+     */
+    public void setDomainObjectRenamingRule(DomainObjectRenamingRule domainObjectRenamingRule) {
+        this.domainObjectRenamingRule = domainObjectRenamingRule;
     }
 
     /**

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/config/xml/MyBatisGeneratorConfigurationParser.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/config/xml/MyBatisGeneratorConfigurationParser.java
@@ -43,6 +43,7 @@ import org.mybatis.generator.config.CommentGeneratorConfiguration;
 import org.mybatis.generator.config.Configuration;
 import org.mybatis.generator.config.ConnectionFactoryConfiguration;
 import org.mybatis.generator.config.Context;
+import org.mybatis.generator.config.DomainObjectRenamingRule;
 import org.mybatis.generator.config.GeneratedKey;
 import org.mybatis.generator.config.IgnoredColumn;
 import org.mybatis.generator.config.IgnoredColumnException;
@@ -380,6 +381,8 @@ public class MyBatisGeneratorConfigurationParser {
                 parseIgnoreColumnByRegex(tc, childNode);
             } else if ("generatedKey".equals(childNode.getNodeName())) { //$NON-NLS-1$
                 parseGeneratedKey(tc, childNode);
+            } else if ("domainObjectRenamingRule".equals(childNode.getNodeName())) { //$NON-NLS-1$
+                parseDomainObjectRenamingRule(tc, childNode);
             } else if ("columnRenamingRule".equals(childNode.getNodeName())) { //$NON-NLS-1$
                 parseColumnRenamingRule(tc, childNode);
             }
@@ -503,6 +506,22 @@ public class MyBatisGeneratorConfigurationParser {
         }
 
         icPattern.addException(exception);
+    }
+
+    private void parseDomainObjectRenamingRule(TableConfiguration tc, Node node) {
+        Properties attributes = parseAttributes(node);
+        String searchString = attributes.getProperty("searchString"); //$NON-NLS-1$
+        String replaceString = attributes.getProperty("replaceString"); //$NON-NLS-1$
+
+        DomainObjectRenamingRule dorr = new DomainObjectRenamingRule();
+
+        dorr.setSearchString(searchString);
+
+        if (stringHasValue(replaceString)) {
+            dorr.setReplaceString(replaceString);
+        }
+
+        tc.setDomainObjectRenamingRule(dorr);
     }
 
     private void parseColumnRenamingRule(TableConfiguration tc, Node node) {

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/internal/db/DatabaseIntrospector.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/internal/db/DatabaseIntrospector.java
@@ -699,10 +699,8 @@ public class DatabaseIntrospector {
             // configuration, then some sort of DB default is being returned
             // and we don't want that in our SQL
             FullyQualifiedTable table = new FullyQualifiedTable(
-                    stringHasValue(tc.getCatalog()) ? atn
-                            .getCatalog() : null,
-                    stringHasValue(tc.getSchema()) ? atn
-                            .getSchema() : null,
+                    stringHasValue(tc.getCatalog()) ? atn.getCatalog() : null,
+                    stringHasValue(tc.getSchema()) ? atn.getSchema() : null,
                     atn.getTableName(),
                     tc.getDomainObjectName(),
                     tc.getAlias(),
@@ -710,7 +708,9 @@ public class DatabaseIntrospector {
                     tc.getProperty(PropertyRegistry.TABLE_RUNTIME_CATALOG),
                     tc.getProperty(PropertyRegistry.TABLE_RUNTIME_SCHEMA),
                     tc.getProperty(PropertyRegistry.TABLE_RUNTIME_TABLE_NAME),
-                    delimitIdentifiers, context);
+                    delimitIdentifiers,
+                    tc.getDomainObjectRenamingRule(),
+                    context);
 
             IntrospectedTable introspectedTable = ObjectFactory
                     .createIntrospectedTable(tc, table, context);

--- a/core/mybatis-generator-core/src/main/resources/org/mybatis/generator/config/xml/mybatis-generator-config_1_0.dtd
+++ b/core/mybatis-generator-core/src/main/resources/org/mybatis/generator/config/xml/mybatis-generator-config_1_0.dtd
@@ -150,7 +150,7 @@
   The table element is used to specify a database table that will be the source information
   for a set of generated objects.
 -->
-<!ELEMENT table (property*, generatedKey?, columnRenamingRule?, (columnOverride | ignoreColumn | ignoreColumnsByRegex)*) >
+<!ELEMENT table (property*, generatedKey?, domainObjectRenamingRule?, columnRenamingRule?, (columnOverride | ignoreColumn | ignoreColumnsByRegex)*) >
 <!ATTLIST table
   catalog CDATA #IMPLIED
   schema CDATA #IMPLIED
@@ -227,6 +227,15 @@
   sqlStatement CDATA #REQUIRED
   identity CDATA #IMPLIED
   type CDATA #IMPLIED>
+
+<!--
+  The domainObjectRenamingRule element is used to specify a rule for renaming
+  object domain name before the corresponding domain object name is calculated
+-->
+<!ELEMENT domainObjectRenamingRule EMPTY>
+<!ATTLIST domainObjectRenamingRule
+  searchString CDATA #REQUIRED
+  replaceString CDATA #IMPLIED>
 
 <!--
   The columnRenamingRule element is used to specify a rule for renaming

--- a/core/mybatis-generator-core/src/main/resources/org/mybatis/generator/internal/util/messages/messages.properties
+++ b/core/mybatis-generator-core/src/main/resources/org/mybatis/generator/internal/util/messages/messages.properties
@@ -42,6 +42,7 @@ ValidationError.24=Generated key in table {0} cannot be both "post" and not iden
 ValidationError.25=targetRuntime in context {0} is invalid
 ValidationError.26="column" is required for <except> in table {0}
 ValidationError.27="pattern" is required for <ignoreColumnsByRegex> in table {0}
+ValidationError.28="searchString" is required for DomainObjectRenamingRule in table {0}
 
 RuntimeError.0=configfile is a required parameter
 RuntimeError.1=configfile {0} does not exist

--- a/core/mybatis-generator-core/src/site/site.xml
+++ b/core/mybatis-generator-core/src/site/site.xml
@@ -43,6 +43,7 @@
       <item href="configreference/xmlconfig.html" name="XML Configuration Reference" collapse="true" >
         <item href="configreference/classPathEntry.html" name="&amp;lt;classPathEntry&amp;gt;" />
         <item href="configreference/columnOverride.html" name="&amp;lt;columnOverride&amp;gt;" />
+        <item href="configreference/domainObjectRenamingRule.html" name="&amp;lt;domainObjectRenamingRule&amp;gt;" />
         <item href="configreference/columnRenamingRule.html" name="&amp;lt;columnRenamingRule&amp;gt;" />
         <item href="configreference/commentGenerator.html" name="&amp;lt;commentGenerator&amp;gt;" />
         <item href="configreference/connectionFactory.html" name="&amp;lt;connectionFactory&amp;gt;" />

--- a/core/mybatis-generator-core/src/site/xhtml/configreference/domainObjectRenamingRule.xhtml
+++ b/core/mybatis-generator-core/src/site/xhtml/configreference/domainObjectRenamingRule.xhtml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+       Copyright 2006-2016 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+  <title>The &lt;domainObjectRenamingRule&gt; Element</title>
+  <link rel="stylesheet" type="text/css" href="../mbgstyle.css" />
+</head>
+<body>
+<h1>The &lt;domainObjectRenamingRule&gt; Element</h1>
+<p>MyBatis Generator (MBG) uses the &lt;domainObjectRenamingRule&gt; element
+to rename database tables before calculating the corresponding domain object
+name.  This is useful when all tables have a common prefix that should be
+removed before calculating the domain object name.  For example, suppose some tables
+as the following:</p>
+ <ul>
+   <li>SYS_USER</li>
+   <li>SYS_ROLE</li>
+   <li>SYS_FUNCTION</li>
+ </ul>
+<p>It might be annoying to have the generated domain object name
+ all containing the SYS prefix.  The prefix can be removed by
+ specifying a renaming rule like this:</p>
+
+<p><code>&lt;domainObjectRenamingRule searchString="^SYS_" replaceString="" /&gt;</code></p>
+
+<p>Note that, internally, MBG uses the
+ <code>java.util.regex.Matcher.replaceAll</code> method
+ for this function.  See the documentation for that method
+ and class for examples of the regular expression language used in
+ Java.</p>
+
+<p>If specified, the renaming rule in this element will rename all the names base on the
+ domain object name. Suppose a table named SYS_USER :</p>
+
+<table border="1" cellspacing="0" cellpadding="5">
+  <tr>
+    <th>Class</th>
+    <th>Before using rename rule</th>
+    <th>After using rename rule</th>
+  </tr>
+  <tr>
+    <td>Domain Object</td>
+    <td>SysUser</td>
+    <td>User</td>
+  </tr>
+  <tr>
+    <td>Key</td>
+    <td>SysUserKey</td>
+    <td>UserKey</td>
+  </tr>
+  <tr>
+    <td>Blob</td>
+    <td>SysUserWithBLOBs</td>
+    <td>UserWithBLOBs</td>
+  </tr>
+  <tr>
+    <td>Example</td>
+    <td>SysUserExample</td>
+    <td>UserExample</td>
+  </tr>
+  <tr>
+    <td>Mapper</td>
+    <td>SysUserMapper</td>
+    <td>UserMapper</td>
+  </tr>
+</table>
+
+<p>This element is an optional child
+element of the <a href="table.html">&lt;table&gt;</a> element.</p>
+
+<h2>Required Attributes</h2>
+<table border="1" cellspacing="0" cellpadding="5">
+  <tr>
+    <th>Attribute</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td>searchString</td>
+    <td>This is a regular expression that defines the substring to be replaced.</td>
+  </tr>
+</table>
+
+<h2>Optional Attributes</h2>
+<table border="1" cellspacing="0" cellpadding="5">
+  <tr>
+    <th>Attribute</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td>replaceString</td>
+    <td>This is a string to be substituted for every occurrence of the
+        search string.  If not specified, the empty string is used.</td>
+  </tr>
+</table>
+
+<h2>Child Elements</h2>
+<p>None</p>
+
+</body>
+</html>

--- a/core/mybatis-generator-core/src/site/xhtml/configreference/table.xhtml
+++ b/core/mybatis-generator-core/src/site/xhtml/configreference/table.xhtml
@@ -295,6 +295,7 @@ identifiers in upper case.  In this instance, you should specify the attribute
 <ul>
   <li><a href="property.html">&lt;property&gt;</a> (0..N)</li>
   <li><a href="generatedKey.html">&lt;generatedKey&gt;</a> (0 or 1)</li>
+  <li><a href="domainObjectRenamingRule.html">&lt;domainObjectRenamingRule&gt;</a> (0 or 1)</li>
   <li><a href="columnRenamingRule.html">&lt;columnRenamingRule&gt;</a> (0 or 1)</li>
   <li><a href="columnOverride.html">&lt;columnOverride&gt;</a> (0..N)</li>
   <li><a href="ignoreColumn.html">&lt;ignoreColumn&gt;</a> (0..N)</li>


### PR DESCRIPTION
`DomainObjectRenamingRule` class  is used to specify a renaming rule for table's domain object name. If `domainObjectName` is not configured, we'll build the domain object named based on the `tableName` or `runtimeTableName`. And then we use the domain object renameing rule to generate the final domain object name. 

For example, if some tables are named:
- SYS_USER
- SYS_ROLE
- SYS_FUNCTIONS

Sometimes, it might be annoying to have the generated domain name all containing the `SYS` prefix. This class can be used to remove the prefix by specifying

```
searchString = "^SYS"
replaceString=""
```

Note that internally, the generator uses the `java.util.regex.Matcher.replaceAll` method for this function. See the documentation of that method for example of the regular expression language used in Java.

In generatreConfig.xml, use like this:

``` xml
<table tableName="sys%">
    <generatedKey column="id" sqlStatement="Mysql"/>
    <domainObjectRenamingRule searchString="^Sys"/>
</table>
```

`SYS_USER` corresponding to the names of all the following:
- `User`
- `UserExample`
- `UserMapper`
- `UserMapper.xml`
