### PR TITLE
Use column name wildcard rather than null with DatabaseMetaData.getColumns()

### DIFF
--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/internal/db/DatabaseIntrospector.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/internal/db/DatabaseIntrospector.java
@@ -600,7 +600,7 @@ public class DatabaseIntrospector {
         }
 
         ResultSet rs = databaseMetaData.getColumns(localCatalog, localSchema,
-                localTableName, null);
+                localTableName, "%"); //$NON-NLS-1$
         
         boolean supportsIsAutoIncrement = false;
         boolean supportsIsGeneratedColumn = false;


### PR DESCRIPTION
This is breaking in newer MySql drivers and the spec is a bit ambiguous
about what is proper here.  This change should work for all drivers.

This fixes #146 