### PR TITLE
Configure auto-commit behaviour in SqlScriptRunner

### DIFF
--- a/core/mybatis-generator-maven-plugin/src/main/java/org/mybatis/generator/maven/SqlScriptRunner.java
+++ b/core/mybatis-generator-maven-plugin/src/main/java/org/mybatis/generator/maven/SqlScriptRunner.java
@@ -77,6 +77,7 @@ public class SqlScriptRunner {
         try {
             Class.forName(driver);
             connection = DriverManager.getConnection(url, userid, password);
+            connection.setAutoCommit(false);
 
             Statement statement = connection.createStatement();
 


### PR DESCRIPTION
This pull requests updates the `SqlScriptRunner` in the Maven plugin to explicitly switch off auto-commit before running the script.

Currently, if I use the driver `org.sqlite.JDBC` ([xerial/sqlite-jdbc](https://github.com/xerial/sqlite-jdbc)) with the maven plugin, then using a startup script will always fail. This is because the driver has auto-commit enabled by default, causing an `SQLException` when the script runner calls `commit()`.

Based on the [relevant doco](https://docs.oracle.com/javase/7/docs/api/java/sql/Connection.html#setAutoCommit(boolean)), this operation should be a no-op on drivers which have auto-commit disabled by default.