### PR TITLE
Better Import Control and Test Harness Enhancements

### DIFF
--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/AbstractJavaMapperMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/AbstractJavaMapperMethodGenerator.java
@@ -74,21 +74,17 @@ public abstract class AbstractJavaMapperMethodGenerator extends
         return sb.toString();
     }
 
-    protected void addGeneratedKeyAnnotation(Interface interfaze, Method method,
-            GeneratedKey gk) {
+    protected void addGeneratedKeyAnnotation(Method method, GeneratedKey gk) {
         StringBuilder sb = new StringBuilder();
         IntrospectedColumn introspectedColumn = introspectedTable.getColumn(gk.getColumn());
         if (introspectedColumn != null) {
             if (gk.isJdbcStandard()) {
-                interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.Options")); //$NON-NLS-1$
                 sb.append("@Options(useGeneratedKeys=true,keyProperty=\""); //$NON-NLS-1$
                 sb.append(introspectedColumn.getJavaProperty());
                 sb.append("\")"); //$NON-NLS-1$
                 method.addAnnotation(sb.toString());
             } else {
-                interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.SelectKey")); //$NON-NLS-1$
                 FullyQualifiedJavaType fqjt = introspectedColumn.getFullyQualifiedJavaType();
-                interfaze.addImportedType(fqjt);
                 sb.append("@SelectKey(statement=\""); //$NON-NLS-1$
                 sb.append(gk.getRuntimeSqlStatement());
                 sb.append("\", keyProperty=\""); //$NON-NLS-1$
@@ -99,6 +95,19 @@ public abstract class AbstractJavaMapperMethodGenerator extends
                 sb.append(fqjt.getShortName());
                 sb.append(".class)"); //$NON-NLS-1$
                 method.addAnnotation(sb.toString());
+            }
+        }
+    }
+    
+    protected void addGeneratedKeyImports(Interface interfaze, GeneratedKey gk) {
+        IntrospectedColumn introspectedColumn = introspectedTable.getColumn(gk.getColumn());
+        if (introspectedColumn != null) {
+            if (gk.isJdbcStandard()) {
+                interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.Options")); //$NON-NLS-1$
+            } else {
+                interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.SelectKey")); //$NON-NLS-1$
+                FullyQualifiedJavaType fqjt = introspectedColumn.getFullyQualifiedJavaType();
+                interfaze.addImportedType(fqjt);
             }
         }
     }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/CountByExampleMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/CountByExampleMethodGenerator.java
@@ -52,15 +52,19 @@ public class CountByExampleMethodGenerator extends
         context.getCommentGenerator().addGeneralMethodComment(method,
                 introspectedTable);
 
-        addMapperAnnotations(interfaze, method);
+        addMapperAnnotations(method);
         
         if (context.getPlugins().clientCountByExampleMethodGenerated(method,
                 interfaze, introspectedTable)) {
+            addExtraImports(interfaze);
             interfaze.addImportedTypes(importedTypes);
             interfaze.addMethod(method);
         }
     }
 
-    public void addMapperAnnotations(Interface interfaze, Method method) {
+    public void addMapperAnnotations(Method method) {
+    }
+
+    public void addExtraImports(Interface interfaze) {
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/DeleteByExampleMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/DeleteByExampleMethodGenerator.java
@@ -52,15 +52,20 @@ public class DeleteByExampleMethodGenerator extends
         context.getCommentGenerator().addGeneralMethodComment(method,
                 introspectedTable);
 
-        addMapperAnnotations(interfaze, method);
+        addMapperAnnotations(method);
         
         if (context.getPlugins().clientDeleteByExampleMethodGenerated(
                 method, interfaze, introspectedTable)) {
+            addExtraImports(interfaze);
             interfaze.addImportedTypes(importedTypes);
             interfaze.addMethod(method);
         }
     }
 
-    public void addMapperAnnotations(Interface interfaze, Method method) {
+    public void addMapperAnnotations(Method method) {
+    }
+    
+    public void addExtraImports(Interface interfaze) {
+        
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/DeleteByPrimaryKeyMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/DeleteByPrimaryKeyMethodGenerator.java
@@ -87,15 +87,19 @@ public class DeleteByPrimaryKeyMethodGenerator extends
         context.getCommentGenerator().addGeneralMethodComment(method,
                 introspectedTable);
 
-        addMapperAnnotations(interfaze, method);
+        addMapperAnnotations(method);
         
         if (context.getPlugins().clientDeleteByPrimaryKeyMethodGenerated(
                 method, interfaze, introspectedTable)) {
+            addExtraImports(interfaze);
             interfaze.addImportedTypes(importedTypes);
             interfaze.addMethod(method);
         }
     }
 
-    public void addMapperAnnotations(Interface interfaze, Method method) {
+    public void addMapperAnnotations(Method method) {
+    }
+
+    public void addExtraImports(Interface interfaze) {
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/InsertMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/InsertMethodGenerator.java
@@ -62,15 +62,19 @@ public class InsertMethodGenerator extends AbstractJavaMapperMethodGenerator {
         context.getCommentGenerator().addGeneralMethodComment(method,
                 introspectedTable);
 
-        addMapperAnnotations(interfaze, method);
+        addMapperAnnotations(method);
 
         if (context.getPlugins().clientInsertMethodGenerated(method, interfaze,
                 introspectedTable)) {
+            addExtraImports(interfaze);
             interfaze.addImportedTypes(importedTypes);
             interfaze.addMethod(method);
         }
     }
 
-    public void addMapperAnnotations(Interface interfaze, Method method) {
+    public void addMapperAnnotations(Method method) {
+    }
+
+    public void addExtraImports(Interface interfaze) {
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/InsertSelectiveMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/InsertSelectiveMethodGenerator.java
@@ -54,15 +54,19 @@ public class InsertSelectiveMethodGenerator extends
         context.getCommentGenerator().addGeneralMethodComment(method,
                 introspectedTable);
 
-        addMapperAnnotations(interfaze, method);
+        addMapperAnnotations(method);
         
         if (context.getPlugins().clientInsertSelectiveMethodGenerated(
                 method, interfaze, introspectedTable)) {
+            addExtraImports(interfaze);
             interfaze.addImportedTypes(importedTypes);
             interfaze.addMethod(method);
         }
     }
 
-    public void addMapperAnnotations(Interface interfaze, Method method) {
+    public void addMapperAnnotations(Method method) {
+    }
+
+    public void addExtraImports(Interface interfaze) {
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/SelectAllMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/SelectAllMethodGenerator.java
@@ -61,11 +61,15 @@ public class SelectAllMethodGenerator extends AbstractJavaMapperMethodGenerator 
 
         if (context.getPlugins().clientSelectAllMethodGenerated(method,
                 interfaze, introspectedTable)) {
+            addExtraImports(interfaze);
             interfaze.addImportedTypes(importedTypes);
             interfaze.addMethod(method);
         }
     }
 
     public void addMapperAnnotations(Interface interfaze, Method method) {
+    }
+
+    public void addExtraImports(Interface interfaze) {
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/SelectByExampleWithBLOBsMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/SelectByExampleWithBLOBsMethodGenerator.java
@@ -74,11 +74,15 @@ public class SelectByExampleWithBLOBsMethodGenerator extends
         if (context.getPlugins()
                 .clientSelectByExampleWithBLOBsMethodGenerated(method, interfaze,
                         introspectedTable)) {
+            addExtraImports(interfaze);
             interfaze.addImportedTypes(importedTypes);
             interfaze.addMethod(method);
         }
     }
 
     public void addMapperAnnotations(Interface interfaze, Method method) {
+    }
+
+    public void addExtraImports(Interface interfaze) {
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/SelectByExampleWithoutBLOBsMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/SelectByExampleWithoutBLOBsMethodGenerator.java
@@ -77,11 +77,15 @@ public class SelectByExampleWithoutBLOBsMethodGenerator extends
         if (context.getPlugins()
                 .clientSelectByExampleWithoutBLOBsMethodGenerated(method,
                         interfaze, introspectedTable)) {
+            addExtraImports(interfaze);
             interfaze.addImportedTypes(importedTypes);
             interfaze.addMethod(method);
         }
     }
 
     public void addMapperAnnotations(Interface interfaze, Method method) {
+    }
+
+    public void addExtraImports(Interface interfaze) {
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/SelectByPrimaryKeyMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/SelectByPrimaryKeyMethodGenerator.java
@@ -96,11 +96,15 @@ public class SelectByPrimaryKeyMethodGenerator extends
 
         if (context.getPlugins().clientSelectByPrimaryKeyMethodGenerated(
                 method, interfaze, introspectedTable)) {
+            addExtraImports(interfaze);
             interfaze.addImportedTypes(importedTypes);
             interfaze.addMethod(method);
         }
     }
 
     public void addMapperAnnotations(Interface interfaze, Method method) {
+    }
+
+    public void addExtraImports(Interface interfaze) {
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/UpdateByExampleSelectiveMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/UpdateByExampleSelectiveMethodGenerator.java
@@ -59,16 +59,20 @@ public class UpdateByExampleSelectiveMethodGenerator extends
         context.getCommentGenerator().addGeneralMethodComment(method,
                 introspectedTable);
 
-        addMapperAnnotations(interfaze, method);
+        addMapperAnnotations(method);
         
         if (context.getPlugins()
                 .clientUpdateByExampleSelectiveMethodGenerated(method, interfaze,
                         introspectedTable)) {
+            addExtraImports(interfaze);
             interfaze.addImportedTypes(importedTypes);
             interfaze.addMethod(method);
         }
     }
 
-    public void addMapperAnnotations(Interface interfaze, Method method) {
+    public void addMapperAnnotations(Method method) {
+    }
+
+    public void addExtraImports(Interface interfaze) {
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/UpdateByExampleWithBLOBsMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/UpdateByExampleWithBLOBsMethodGenerator.java
@@ -69,16 +69,20 @@ public class UpdateByExampleWithBLOBsMethodGenerator extends
         context.getCommentGenerator().addGeneralMethodComment(method,
                 introspectedTable);
 
-        addMapperAnnotations(interfaze, method);
+        addMapperAnnotations(method);
         
         if (context.getPlugins()
                 .clientUpdateByExampleWithBLOBsMethodGenerated(method, interfaze,
                         introspectedTable)) {
+            addExtraImports(interfaze);
             interfaze.addImportedTypes(importedTypes);
             interfaze.addMethod(method);
         }
     }
     
-    public void addMapperAnnotations(Interface interfaze, Method method) {
+    public void addMapperAnnotations(Method method) {
+    }
+
+    public void addExtraImports(Interface interfaze) {
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/UpdateByExampleWithoutBLOBsMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/UpdateByExampleWithoutBLOBsMethodGenerator.java
@@ -68,16 +68,20 @@ public class UpdateByExampleWithoutBLOBsMethodGenerator extends
         context.getCommentGenerator().addGeneralMethodComment(method,
                 introspectedTable);
 
-        addMapperAnnotations(interfaze, method);
+        addMapperAnnotations(method);
         
         if (context.getPlugins()
                 .clientUpdateByExampleWithoutBLOBsMethodGenerated(method,
                         interfaze, introspectedTable)) {
+            addExtraImports(interfaze);
             interfaze.addImportedTypes(importedTypes);
             interfaze.addMethod(method);
         }
     }
 
-    public void addMapperAnnotations(Interface interfaze, Method method) {
+    public void addMapperAnnotations(Method method) {
+    }
+
+    public void addExtraImports(Interface interfaze) {
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/UpdateByPrimaryKeySelectiveMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/UpdateByPrimaryKeySelectiveMethodGenerator.java
@@ -61,16 +61,20 @@ public class UpdateByPrimaryKeySelectiveMethodGenerator extends
         context.getCommentGenerator().addGeneralMethodComment(method,
                 introspectedTable);
 
-        addMapperAnnotations(interfaze, method);
+        addMapperAnnotations(method);
         
         if (context.getPlugins()
                 .clientUpdateByPrimaryKeySelectiveMethodGenerated(method,
                         interfaze, introspectedTable)) {
+            addExtraImports(interfaze);
             interfaze.addImportedTypes(importedTypes);
             interfaze.addMethod(method);
         }
     }
 
-    public void addMapperAnnotations(Interface interfaze, Method method) {
+    public void addMapperAnnotations(Method method) {
+    }
+
+    public void addExtraImports(Interface interfaze) {
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/UpdateByPrimaryKeyWithBLOBsMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/UpdateByPrimaryKeyWithBLOBsMethodGenerator.java
@@ -62,16 +62,20 @@ public class UpdateByPrimaryKeyWithBLOBsMethodGenerator extends
         context.getCommentGenerator().addGeneralMethodComment(method,
                 introspectedTable);
 
-        addMapperAnnotations(interfaze, method);
+        addMapperAnnotations(method);
 
         if (context.getPlugins()
                 .clientUpdateByPrimaryKeyWithBLOBsMethodGenerated(method,
                         interfaze, introspectedTable)) {
+            addExtraImports(interfaze);
             interfaze.addImportedTypes(importedTypes);
             interfaze.addMethod(method);
         }
     }
 
-    public void addMapperAnnotations(Interface interfaze, Method method) {
+    public void addMapperAnnotations(Method method) {
+    }
+
+    public void addExtraImports(Interface interfaze) {
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/UpdateByPrimaryKeyWithoutBLOBsMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/UpdateByPrimaryKeyWithoutBLOBsMethodGenerator.java
@@ -52,16 +52,20 @@ public class UpdateByPrimaryKeyWithoutBLOBsMethodGenerator extends
         context.getCommentGenerator().addGeneralMethodComment(method,
                 introspectedTable);
 
-        addMapperAnnotations(interfaze, method);
+        addMapperAnnotations(method);
         
         if (context.getPlugins()
                 .clientUpdateByPrimaryKeyWithoutBLOBsMethodGenerated(method,
                         interfaze, introspectedTable)) {
+            addExtraImports(interfaze);
             interfaze.addImportedTypes(importedTypes);
             interfaze.addMethod(method);
         }
     }
 
-    public void addMapperAnnotations(Interface interfaze, Method method) {
+    public void addMapperAnnotations(Method method) {
+    }
+
+    public void addExtraImports(Interface interfaze) {
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/annotated/AnnotatedCountByExampleMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/annotated/AnnotatedCountByExampleMethodGenerator.java
@@ -32,9 +32,8 @@ public class AnnotatedCountByExampleMethodGenerator extends
     }
 
     @Override
-    public void addMapperAnnotations(Interface interfaze, Method method) {
+    public void addMapperAnnotations(Method method) {
         FullyQualifiedJavaType fqjt = new FullyQualifiedJavaType(introspectedTable.getMyBatis3SqlProviderType());
-        interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.SelectProvider")); //$NON-NLS-1$
         StringBuilder sb = new StringBuilder();
         sb.append("@SelectProvider(type="); //$NON-NLS-1$
         sb.append(fqjt.getShortName());
@@ -43,5 +42,10 @@ public class AnnotatedCountByExampleMethodGenerator extends
         sb.append("\")"); //$NON-NLS-1$
         
         method.addAnnotation(sb.toString());
+    }
+
+    @Override
+    public void addExtraImports(Interface interfaze) {
+        interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.SelectProvider")); //$NON-NLS-1$
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/annotated/AnnotatedDeleteByExampleMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/annotated/AnnotatedDeleteByExampleMethodGenerator.java
@@ -32,9 +32,8 @@ public class AnnotatedDeleteByExampleMethodGenerator extends
     }
 
     @Override
-    public void addMapperAnnotations(Interface interfaze, Method method) {
+    public void addMapperAnnotations(Method method) {
         FullyQualifiedJavaType fqjt = new FullyQualifiedJavaType(introspectedTable.getMyBatis3SqlProviderType());
-        interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.DeleteProvider")); //$NON-NLS-1$
         StringBuilder sb = new StringBuilder();
         sb.append("@DeleteProvider(type="); //$NON-NLS-1$
         sb.append(fqjt.getShortName());
@@ -43,5 +42,10 @@ public class AnnotatedDeleteByExampleMethodGenerator extends
         sb.append("\")"); //$NON-NLS-1$
         
         method.addAnnotation(sb.toString());
+    }
+
+    @Override
+    public void addExtraImports(Interface interfaze) {
+        interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.DeleteProvider")); //$NON-NLS-1$
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/annotated/AnnotatedDeleteByPrimaryKeyMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/annotated/AnnotatedDeleteByPrimaryKeyMethodGenerator.java
@@ -40,8 +40,7 @@ public class AnnotatedDeleteByPrimaryKeyMethodGenerator extends
     }
 
     @Override
-    public void addMapperAnnotations(Interface interfaze, Method method) {
-        interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.Delete")); //$NON-NLS-1$
+    public void addMapperAnnotations(Method method) {
         
         method.addAnnotation("@Delete({"); //$NON-NLS-1$
         
@@ -79,5 +78,10 @@ public class AnnotatedDeleteByPrimaryKeyMethodGenerator extends
         }
         
         method.addAnnotation("})"); //$NON-NLS-1$
+    }
+
+    @Override
+    public void addExtraImports(Interface interfaze) {
+        interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.Delete")); //$NON-NLS-1$
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/annotated/AnnotatedInsertMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/annotated/AnnotatedInsertMethodGenerator.java
@@ -44,8 +44,7 @@ public class AnnotatedInsertMethodGenerator extends
     }
 
     @Override
-    public void addMapperAnnotations(Interface interfaze, Method method) {
-        interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.Insert")); //$NON-NLS-1$
+    public void addMapperAnnotations(Method method) {
         
         GeneratedKey gk = introspectedTable.getGeneratedKey();
         
@@ -117,7 +116,16 @@ public class AnnotatedInsertMethodGenerator extends
         method.addAnnotation("})"); //$NON-NLS-1$
 
         if (gk != null) {
-            addGeneratedKeyAnnotation(interfaze, method, gk);
+            addGeneratedKeyAnnotation(method, gk);
         }
+    }
+    
+    @Override
+    public void addExtraImports(Interface interfaze) {
+        GeneratedKey gk = introspectedTable.getGeneratedKey();
+        if (gk != null) {
+            addGeneratedKeyImports(interfaze, gk);
+        }
+        interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.Insert")); //$NON-NLS-1$
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/annotated/AnnotatedInsertSelectiveMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/annotated/AnnotatedInsertSelectiveMethodGenerator.java
@@ -33,9 +33,8 @@ public class AnnotatedInsertSelectiveMethodGenerator extends
     }
 
     @Override
-    public void addMapperAnnotations(Interface interfaze, Method method) {
+    public void addMapperAnnotations(Method method) {
         FullyQualifiedJavaType fqjt = new FullyQualifiedJavaType(introspectedTable.getMyBatis3SqlProviderType());
-        interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.InsertProvider")); //$NON-NLS-1$
         StringBuilder sb = new StringBuilder();
         sb.append("@InsertProvider(type="); //$NON-NLS-1$
         sb.append(fqjt.getShortName());
@@ -47,7 +46,16 @@ public class AnnotatedInsertSelectiveMethodGenerator extends
 
         GeneratedKey gk = introspectedTable.getGeneratedKey();
         if (gk != null) {
-            addGeneratedKeyAnnotation(interfaze, method, gk);
+            addGeneratedKeyAnnotation(method, gk);
         }
+    }
+
+    @Override
+    public void addExtraImports(Interface interfaze) {
+        GeneratedKey gk = introspectedTable.getGeneratedKey();
+        if (gk != null) {
+            addGeneratedKeyImports(interfaze, gk);
+        }
+        interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.InsertProvider")); //$NON-NLS-1$
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/annotated/AnnotatedSelectAllMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/annotated/AnnotatedSelectAllMethodGenerator.java
@@ -109,15 +109,10 @@ public class AnnotatedSelectAllMethodGenerator extends
     }
     
     private void addAnnotatedResults(Interface interfaze, Method method) {
-        interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.type.JdbcType")); //$NON-NLS-1$
         
         if (introspectedTable.isConstructorBased()) {
-            interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.Arg")); //$NON-NLS-1$
-            interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.ConstructorArgs")); //$NON-NLS-1$
             method.addAnnotation("@ConstructorArgs({"); //$NON-NLS-1$
         } else {
-            interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.Result")); //$NON-NLS-1$
-            interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.Results")); //$NON-NLS-1$
             method.addAnnotation("@Results({"); //$NON-NLS-1$
         }
         
@@ -154,5 +149,17 @@ public class AnnotatedSelectAllMethodGenerator extends
         }
         
         method.addAnnotation("})"); //$NON-NLS-1$
+    }
+
+    @Override
+    public void addExtraImports(Interface interfaze) {
+        interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.type.JdbcType")); //$NON-NLS-1$
+        if (introspectedTable.isConstructorBased()) {
+            interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.Arg")); //$NON-NLS-1$
+            interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.ConstructorArgs")); //$NON-NLS-1$
+        } else {
+            interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.Result")); //$NON-NLS-1$
+            interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.Results")); //$NON-NLS-1$
+        }
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/annotated/AnnotatedSelectByExampleWithBLOBsMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/annotated/AnnotatedSelectByExampleWithBLOBsMethodGenerator.java
@@ -39,16 +39,6 @@ public class AnnotatedSelectByExampleWithBLOBsMethodGenerator extends
     @Override
     public void addMapperAnnotations(Interface interfaze, Method method) {
         FullyQualifiedJavaType fqjt = new FullyQualifiedJavaType(introspectedTable.getMyBatis3SqlProviderType());
-        interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.SelectProvider")); //$NON-NLS-1$
-        interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.type.JdbcType")); //$NON-NLS-1$
-
-        if (introspectedTable.isConstructorBased()) {
-            interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.Arg")); //$NON-NLS-1$
-            interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.ConstructorArgs")); //$NON-NLS-1$
-        } else {
-            interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.Result")); //$NON-NLS-1$
-            interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.Results")); //$NON-NLS-1$
-        }
         
         StringBuilder sb = new StringBuilder();
         sb.append("@SelectProvider(type="); //$NON-NLS-1$
@@ -96,5 +86,19 @@ public class AnnotatedSelectByExampleWithBLOBsMethodGenerator extends
         }
         
         method.addAnnotation("})"); //$NON-NLS-1$
+    }
+    
+    @Override
+    public void addExtraImports(Interface interfaze) {
+        interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.SelectProvider")); //$NON-NLS-1$
+        interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.type.JdbcType")); //$NON-NLS-1$
+
+        if (introspectedTable.isConstructorBased()) {
+            interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.Arg")); //$NON-NLS-1$
+            interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.ConstructorArgs")); //$NON-NLS-1$
+        } else {
+            interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.Result")); //$NON-NLS-1$
+            interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.Results")); //$NON-NLS-1$
+        }
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/annotated/AnnotatedSelectByExampleWithoutBLOBsMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/annotated/AnnotatedSelectByExampleWithoutBLOBsMethodGenerator.java
@@ -39,16 +39,6 @@ public class AnnotatedSelectByExampleWithoutBLOBsMethodGenerator extends
     @Override
     public void addMapperAnnotations(Interface interfaze, Method method) {
         FullyQualifiedJavaType fqjt = new FullyQualifiedJavaType(introspectedTable.getMyBatis3SqlProviderType());
-        interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.SelectProvider")); //$NON-NLS-1$
-        interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.type.JdbcType")); //$NON-NLS-1$
-
-        if (introspectedTable.isConstructorBased()) {
-            interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.Arg")); //$NON-NLS-1$
-            interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.ConstructorArgs")); //$NON-NLS-1$
-        } else {
-            interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.Result")); //$NON-NLS-1$
-            interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.Results")); //$NON-NLS-1$
-        }
         
         StringBuilder sb = new StringBuilder();
         sb.append("@SelectProvider(type="); //$NON-NLS-1$
@@ -96,5 +86,19 @@ public class AnnotatedSelectByExampleWithoutBLOBsMethodGenerator extends
         }
         
         method.addAnnotation("})"); //$NON-NLS-1$
+    }
+
+    @Override
+    public void addExtraImports(Interface interfaze) {
+        interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.SelectProvider")); //$NON-NLS-1$
+        interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.type.JdbcType")); //$NON-NLS-1$
+
+        if (introspectedTable.isConstructorBased()) {
+            interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.Arg")); //$NON-NLS-1$
+            interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.ConstructorArgs")); //$NON-NLS-1$
+        } else {
+            interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.Result")); //$NON-NLS-1$
+            interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.Results")); //$NON-NLS-1$
+        }
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/annotated/AnnotatedSelectByPrimaryKeyMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/annotated/AnnotatedSelectByPrimaryKeyMethodGenerator.java
@@ -45,7 +45,6 @@ public class AnnotatedSelectByPrimaryKeyMethodGenerator extends
 
     @Override
     public void addMapperAnnotations(Interface interfaze, Method method) {
-        interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.Select")); //$NON-NLS-1$
 
         StringBuilder sb = new StringBuilder();
         method.addAnnotation("@Select({"); //$NON-NLS-1$
@@ -120,7 +119,7 @@ public class AnnotatedSelectByPrimaryKeyMethodGenerator extends
         if (useResultMapIfAvailable) {
             if (introspectedTable.getRules().generateBaseResultMap()
                     || introspectedTable.getRules().generateResultMapWithBLOBs()) {
-                addResultMapAnnotation(interfaze, method);
+                addResultMapAnnotation(method);
             } else {
                 addAnnotatedResults(interfaze, method);
             }
@@ -129,8 +128,7 @@ public class AnnotatedSelectByPrimaryKeyMethodGenerator extends
         }
     }
     
-    private void addResultMapAnnotation(Interface interfaze, Method method) {
-        interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.ResultMap")); //$NON-NLS-1$
+    private void addResultMapAnnotation(Method method) {
         
         String annotation = String.format("@ResultMap(\"%s.%s\")", //$NON-NLS-1$
         		introspectedTable.getMyBatis3SqlMapNamespace(),
@@ -140,15 +138,10 @@ public class AnnotatedSelectByPrimaryKeyMethodGenerator extends
     }
     
     private void addAnnotatedResults(Interface interfaze, Method method) {
-        interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.type.JdbcType")); //$NON-NLS-1$
         
         if (introspectedTable.isConstructorBased()) {
-            interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.Arg")); //$NON-NLS-1$
-            interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.ConstructorArgs")); //$NON-NLS-1$
             method.addAnnotation("@ConstructorArgs({"); //$NON-NLS-1$
         } else {
-            interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.Result")); //$NON-NLS-1$
-            interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.Results")); //$NON-NLS-1$
             method.addAnnotation("@Results({"); //$NON-NLS-1$
         }
         
@@ -185,5 +178,33 @@ public class AnnotatedSelectByPrimaryKeyMethodGenerator extends
         }
         
         method.addAnnotation("})"); //$NON-NLS-1$
+    }
+
+    @Override
+    public void addExtraImports(Interface interfaze) {
+        interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.Select")); //$NON-NLS-1$
+
+        if (useResultMapIfAvailable) {
+            if (introspectedTable.getRules().generateBaseResultMap()
+                    || introspectedTable.getRules().generateResultMapWithBLOBs()) {
+                interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.ResultMap")); //$NON-NLS-1$
+            } else {
+                addAnnotationImports(interfaze);
+            }
+        } else {
+            addAnnotationImports(interfaze);
+        }
+    }
+    
+    private void addAnnotationImports(Interface interfaze) {
+        interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.type.JdbcType")); //$NON-NLS-1$
+        
+        if (introspectedTable.isConstructorBased()) {
+            interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.Arg")); //$NON-NLS-1$
+            interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.ConstructorArgs")); //$NON-NLS-1$
+        } else {
+            interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.Result")); //$NON-NLS-1$
+            interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.Results")); //$NON-NLS-1$
+        }
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/annotated/AnnotatedUpdateByExampleSelectiveMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/annotated/AnnotatedUpdateByExampleSelectiveMethodGenerator.java
@@ -32,9 +32,8 @@ public class AnnotatedUpdateByExampleSelectiveMethodGenerator extends
     }
 
     @Override
-    public void addMapperAnnotations(Interface interfaze, Method method) {
+    public void addMapperAnnotations(Method method) {
         FullyQualifiedJavaType fqjt = new FullyQualifiedJavaType(introspectedTable.getMyBatis3SqlProviderType());
-        interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.UpdateProvider")); //$NON-NLS-1$
         StringBuilder sb = new StringBuilder();
         sb.append("@UpdateProvider(type="); //$NON-NLS-1$
         sb.append(fqjt.getShortName());
@@ -43,5 +42,10 @@ public class AnnotatedUpdateByExampleSelectiveMethodGenerator extends
         sb.append("\")"); //$NON-NLS-1$
         
         method.addAnnotation(sb.toString());
+    }
+
+    @Override
+    public void addExtraImports(Interface interfaze) {
+        interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.UpdateProvider")); //$NON-NLS-1$
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/annotated/AnnotatedUpdateByExampleWithBLOBsMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/annotated/AnnotatedUpdateByExampleWithBLOBsMethodGenerator.java
@@ -32,9 +32,8 @@ public class AnnotatedUpdateByExampleWithBLOBsMethodGenerator extends
     }
 
     @Override
-    public void addMapperAnnotations(Interface interfaze, Method method) {
+    public void addMapperAnnotations(Method method) {
         FullyQualifiedJavaType fqjt = new FullyQualifiedJavaType(introspectedTable.getMyBatis3SqlProviderType());
-        interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.UpdateProvider")); //$NON-NLS-1$
         StringBuilder sb = new StringBuilder();
         sb.append("@UpdateProvider(type="); //$NON-NLS-1$
         sb.append(fqjt.getShortName());
@@ -43,5 +42,10 @@ public class AnnotatedUpdateByExampleWithBLOBsMethodGenerator extends
         sb.append("\")"); //$NON-NLS-1$
         
         method.addAnnotation(sb.toString());
+    }
+
+    @Override
+    public void addExtraImports(Interface interfaze) {
+        interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.UpdateProvider")); //$NON-NLS-1$
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/annotated/AnnotatedUpdateByExampleWithoutBLOBsMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/annotated/AnnotatedUpdateByExampleWithoutBLOBsMethodGenerator.java
@@ -32,9 +32,8 @@ public class AnnotatedUpdateByExampleWithoutBLOBsMethodGenerator extends
     }
 
     @Override
-    public void addMapperAnnotations(Interface interfaze, Method method) {
+    public void addMapperAnnotations(Method method) {
         FullyQualifiedJavaType fqjt = new FullyQualifiedJavaType(introspectedTable.getMyBatis3SqlProviderType());
-        interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.UpdateProvider")); //$NON-NLS-1$
         StringBuilder sb = new StringBuilder();
         sb.append("@UpdateProvider(type="); //$NON-NLS-1$
         sb.append(fqjt.getShortName());
@@ -43,5 +42,10 @@ public class AnnotatedUpdateByExampleWithoutBLOBsMethodGenerator extends
         sb.append("\")"); //$NON-NLS-1$
         
         method.addAnnotation(sb.toString());
+    }
+
+    @Override
+    public void addExtraImports(Interface interfaze) {
+        interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.UpdateProvider")); //$NON-NLS-1$
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/annotated/AnnotatedUpdateByPrimaryKeySelectiveMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/annotated/AnnotatedUpdateByPrimaryKeySelectiveMethodGenerator.java
@@ -32,9 +32,8 @@ public class AnnotatedUpdateByPrimaryKeySelectiveMethodGenerator extends
     }
 
     @Override
-    public void addMapperAnnotations(Interface interfaze, Method method) {
+    public void addMapperAnnotations(Method method) {
         FullyQualifiedJavaType fqjt = new FullyQualifiedJavaType(introspectedTable.getMyBatis3SqlProviderType());
-        interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.UpdateProvider")); //$NON-NLS-1$
         StringBuilder sb = new StringBuilder();
         sb.append("@UpdateProvider(type="); //$NON-NLS-1$
         sb.append(fqjt.getShortName());
@@ -43,5 +42,10 @@ public class AnnotatedUpdateByPrimaryKeySelectiveMethodGenerator extends
         sb.append("\")"); //$NON-NLS-1$
         
         method.addAnnotation(sb.toString());
+    }
+
+    @Override
+    public void addExtraImports(Interface interfaze) {
+        interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.UpdateProvider")); //$NON-NLS-1$
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/annotated/AnnotatedUpdateByPrimaryKeyWithBLOBsMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/annotated/AnnotatedUpdateByPrimaryKeyWithBLOBsMethodGenerator.java
@@ -41,8 +41,7 @@ public class AnnotatedUpdateByPrimaryKeyWithBLOBsMethodGenerator extends
     }
 
     @Override
-    public void addMapperAnnotations(Interface interfaze, Method method) {
-        interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.Update")); //$NON-NLS-1$
+    public void addMapperAnnotations(Method method) {
         
         method.addAnnotation("@Update({"); //$NON-NLS-1$
 
@@ -107,5 +106,10 @@ public class AnnotatedUpdateByPrimaryKeyWithBLOBsMethodGenerator extends
         }
         
         method.addAnnotation("})"); //$NON-NLS-1$
+    }
+
+    @Override
+    public void addExtraImports(Interface interfaze) {
+        interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.Update")); //$NON-NLS-1$
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/annotated/AnnotatedUpdateByPrimaryKeyWithoutBLOBsMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/annotated/AnnotatedUpdateByPrimaryKeyWithoutBLOBsMethodGenerator.java
@@ -44,8 +44,7 @@ public class AnnotatedUpdateByPrimaryKeyWithoutBLOBsMethodGenerator extends
     }
 
     @Override
-    public void addMapperAnnotations(Interface interfaze, Method method) {
-        interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.Update")); //$NON-NLS-1$
+    public void addMapperAnnotations(Method method) {
         
         method.addAnnotation("@Update({"); //$NON-NLS-1$
 
@@ -116,5 +115,10 @@ public class AnnotatedUpdateByPrimaryKeyWithoutBLOBsMethodGenerator extends
         }
         
         method.addAnnotation("})"); //$NON-NLS-1$
+    }
+
+    @Override
+    public void addExtraImports(Interface interfaze) {
+        interfaze.addImportedType(new FullyQualifiedJavaType("org.apache.ibatis.annotations.Update")); //$NON-NLS-1$
     }
 }

--- a/eclipse/org.mybatis.generator.eclipse.core.tests/src/org/mybatis/generator/eclipse/core/tests/merge/ExistingJavaFileVisitorTest.java
+++ b/eclipse/org.mybatis.generator.eclipse.core.tests/src/org/mybatis/generator/eclipse/core/tests/merge/ExistingJavaFileVisitorTest.java
@@ -17,6 +17,7 @@ package org.mybatis.generator.eclipse.core.tests.merge;
 
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
+import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.mybatis.generator.eclipse.core.merge.EclipseDomUtils.getCompilationUnitFromSource;
 import static org.mybatis.generator.eclipse.tests.harness.Utilities.getCompilationUnitSummaryFromSource;
@@ -88,7 +89,7 @@ public class ExistingJavaFileVisitorTest {
 
         CompilationUnitSummary summary = getCompilationUnitSummaryFromSource(document.get());
         assertThat(summary, hasImportCount(2));
-        assertThat(summary, hasClass("AwfulTableExample", withSuperClass(null)));
+        assertThat(summary, hasClass("AwfulTableExample", withSuperClass(nullValue())));
         assertThat(summary, hasClass("AwfulTableExample", withSuperInterfaceCount(0)));
         assertThat(summary, hasClass("AwfulTableExample", withMethodCount(0)));
         assertThat(summary, hasClass("AwfulTableExample", withFieldCount(0)));

--- a/eclipse/org.mybatis.generator.eclipse.core.tests/src/org/mybatis/generator/eclipse/core/tests/merge/JavaFileMergerTest.java
+++ b/eclipse/org.mybatis.generator.eclipse.core.tests/src/org/mybatis/generator/eclipse/core/tests/merge/JavaFileMergerTest.java
@@ -15,17 +15,18 @@
  */
 package org.mybatis.generator.eclipse.core.tests.merge;
 
-import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertThat;
-import static org.mybatis.generator.eclipse.core.tests.merge.support.TestResourceGenerator.*;
+import static org.mybatis.generator.eclipse.core.tests.merge.support.TestResourceGenerator.simpleClassWithAllGeneratedItems;
+import static org.mybatis.generator.eclipse.core.tests.merge.support.TestResourceGenerator.simpleClassWithGeneratedAndCustomItems;
+import static org.mybatis.generator.eclipse.core.tests.merge.support.TestResourceGenerator.simpleInterfaceWithAllGeneratedItems;
+import static org.mybatis.generator.eclipse.core.tests.merge.support.TestResourceGenerator.simpleInterfaceWithGeneratedAndCustomItems;
 import static org.mybatis.generator.eclipse.tests.harness.Utilities.getCompilationUnitSummaryFromSource;
 import static org.mybatis.generator.eclipse.tests.harness.matchers.Matchers.*;
 
 import org.junit.Test;
 import org.mybatis.generator.config.MergeConstants;
 import org.mybatis.generator.eclipse.core.merge.JavaFileMerger;
-import org.mybatis.generator.eclipse.tests.harness.summary.ClassSummary;
 import org.mybatis.generator.eclipse.tests.harness.summary.CompilationUnitSummary;
 
 public class JavaFileMergerTest {
@@ -55,10 +56,8 @@ public class JavaFileMergerTest {
         assertThat(summary, hasClass("SimpleClass", withField("amount")));
         assertThat(summary, hasClass("SimpleClass", withField("id")));
         
-        ClassSummary classSummary = summary.getClassSummary("SimpleClass");
-        
-        assertThat(classSummary.getSuperClass(), is(nullValue()));
-   }
+        assertThat(summary, hasClass("SimpleClass", withSuperClass(nullValue())));
+    }
 
     @Test
     public void testMergeOnRegularInterfaces() throws Exception {

--- a/eclipse/org.mybatis.generator.eclipse.tests.harness/src/org/mybatis/generator/eclipse/tests/harness/matchers/HasSuperClass.java
+++ b/eclipse/org.mybatis.generator.eclipse.tests.harness/src/org/mybatis/generator/eclipse/tests/harness/matchers/HasSuperClass.java
@@ -15,42 +15,40 @@
  */
 package org.mybatis.generator.eclipse.tests.harness.matchers;
 
+import static org.hamcrest.core.IsEqual.equalTo;
 import org.hamcrest.Description;
+import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 import org.mybatis.generator.eclipse.tests.harness.summary.ClassSummary;
 
 public class HasSuperClass extends TypeSafeMatcher<ClassSummary>{
 
-    private String superClass;
+    private Matcher<?> matcher;
     
-    public HasSuperClass(String superClass) {
-        this.superClass = superClass;
+    public HasSuperClass(Matcher<?> matcher) {
+        this.matcher = matcher;
     }
     
     @Override
     public void describeTo(Description description) {
-        if (superClass == null) {
-            description.appendText("class has no superclass");
-        } else {
-            description.appendText("class has superclass " + superClass);
-        }
+        description.appendText("superclass is ").appendDescriptionOf(matcher);
     }
 
     @Override
     protected boolean matchesSafely(ClassSummary item) {
-        if (superClass == null) {
-            return item.getSuperClass() == null;
-        } else {
-            return superClass.equals(item.getSuperClass());
-        }
+        return matcher.matches(item.getSuperClass());
     }
 
     @Override
     protected void describeMismatchSafely(ClassSummary item, Description mismatchDescription) {
-        if (item.getSuperClass() == null) {
-            mismatchDescription.appendText("class has no super class");
-        } else {
-            mismatchDescription.appendText("super class was " + item.getSuperClass());
-        }
+        mismatchDescription.appendText("the superclass of " + item.getName() + " is " + item.getSuperClass());
+    }
+    
+    public static HasSuperClass hasSuperClass(Matcher<?> matcher) {
+        return new HasSuperClass(matcher);
+    }
+
+    public static HasSuperClass hasSuperClass(String superClass) {
+        return new HasSuperClass(equalTo(superClass));
     }
 }

--- a/eclipse/org.mybatis.generator.eclipse.tests.harness/src/org/mybatis/generator/eclipse/tests/harness/matchers/Matchers.java
+++ b/eclipse/org.mybatis.generator.eclipse.tests.harness/src/org/mybatis/generator/eclipse/tests/harness/matchers/Matchers.java
@@ -163,13 +163,21 @@ public class Matchers {
     }
 
     public static HasSuperClass hasSuperClass(String superClass) {
-        return new HasSuperClass(superClass);
+        return HasSuperClass.hasSuperClass(superClass);
     }
     
     public static HasSuperClass withSuperClass(String superClass) {
-        return hasSuperClass(superClass);
+        return HasSuperClass.hasSuperClass(superClass);
     }
     
+    public static HasSuperClass hasSuperClass(Matcher<?> matcher) {
+        return HasSuperClass.hasSuperClass(matcher);
+    }
+    
+    public static HasSuperClass withSuperClass(Matcher<?> matcher) {
+        return HasSuperClass.hasSuperClass(matcher);
+    }
+
     public static HasSuperInterface hasSuperInterface(String superInterface) {
         return new HasSuperInterface(superInterface);
     }

--- a/eclipse/org.mybatis.generator.eclipse.tests.harness/src/org/mybatis/generator/eclipse/tests/harness/tests/MatcherTest.java
+++ b/eclipse/org.mybatis.generator.eclipse.tests.harness/src/org/mybatis/generator/eclipse/tests/harness/tests/MatcherTest.java
@@ -15,6 +15,7 @@
  */
 package org.mybatis.generator.eclipse.tests.harness.tests;
 
+import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.mybatis.generator.eclipse.tests.harness.Utilities.getCompilationUnitSummaryFromResource;
 import static org.mybatis.generator.eclipse.tests.harness.matchers.Matchers.*;
@@ -246,12 +247,12 @@ public class MatcherTest {
 
     @Test(expected=AssertionError.class)
     public void testHasClassWithNullSuperClassFails() {
-        assertThat(cuSummary, hasClass(OUTER_CLASS, withSuperClass(null)));
+        assertThat(cuSummary, hasClass(OUTER_CLASS, withSuperClass(nullValue())));
     }
 
     @Test
     public void testHasClassWithNullSuperClassSucceeds() {
-        assertThat(cuSummary, hasClass(SECOND_OUTER_CLASS, withSuperClass(null)));
+        assertThat(cuSummary, hasClass(SECOND_OUTER_CLASS, withSuperClass(nullValue())));
     }
 
     @Test(expected=AssertionError.class)

--- a/eclipse/org.mybatis.generator.eclipse.tests.harness/src/org/mybatis/generator/eclipse/tests/harness/tests/SummarizerTest.java
+++ b/eclipse/org.mybatis.generator.eclipse.tests.harness/src/org/mybatis/generator/eclipse/tests/harness/tests/SummarizerTest.java
@@ -15,6 +15,7 @@
  */
 package org.mybatis.generator.eclipse.tests.harness.tests;
 
+import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.mybatis.generator.eclipse.tests.harness.Utilities.getCompilationUnitSummaryFromResource;
 import static org.mybatis.generator.eclipse.tests.harness.matchers.Matchers.*;
@@ -23,8 +24,8 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import org.junit.Test;
-import org.mybatis.generator.eclipse.tests.harness.summary.AnnotationSummary;
 import org.mybatis.generator.eclipse.tests.harness.summary.AbstractSummary;
+import org.mybatis.generator.eclipse.tests.harness.summary.AnnotationSummary;
 import org.mybatis.generator.eclipse.tests.harness.summary.ClassSummary;
 import org.mybatis.generator.eclipse.tests.harness.summary.CompilationUnitSummary;
 import org.mybatis.generator.eclipse.tests.harness.summary.EnumSummary;
@@ -239,6 +240,6 @@ public class SummarizerTest {
         assertThat(classSummary, hasAnnotationCount(0));
         assertThat(classSummary, hasInterfaceCount(0));
         assertThat(classSummary, hasSuperInterfaceCount(0));
-        assertThat(classSummary, hasSuperClass(null));
+        assertThat(classSummary, hasSuperClass(nullValue()));
     }
 }


### PR DESCRIPTION
1. Don't add imports if the method is disabled by a plugin
2.  Superclass matcher will now respond appropriately to nullValue() matcher