### PR TITLE
Add DTDs to the Eclipse UI Plugin so the XML Catalog can resolve them

### DIFF
--- a/eclipse/org.mybatis.generator.eclipse.ui/build.properties
+++ b/eclipse/org.mybatis.generator.eclipse.ui/build.properties
@@ -6,7 +6,8 @@ bin.includes = META-INF/,\
                LICENSE,\
                NOTICE,\
                icons/,\
-               lib/antsupport.jar
+               lib/antsupport.jar,\
+               dtds/
 jars.compile.order = .,\
                      lib/antsupport.jar
 output.lib/antsupport.jar = antbin/


### PR DESCRIPTION
XML catalog entries are present, but the DTDs are not included in the build.  This breaks the XML catalog entries and causes validation warnings in generator configuration files.