### PR TITLE
fully customize import types in plugin 

### DIFF
--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/Interface.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/Interface.java
@@ -68,7 +68,7 @@ public class Interface extends InnerInterface implements CompilationUnit {
      * @see org.mybatis.generator.api.dom.java.CompilationUnit#getImportedTypes()
      */
     public Set<FullyQualifiedJavaType> getImportedTypes() {
-        return Collections.unmodifiableSet(importedTypes);
+        return importedTypes;
     }
 
     /* (non-Javadoc)

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/TopLevelClass.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/TopLevelClass.java
@@ -70,7 +70,7 @@ public class TopLevelClass extends InnerClass implements CompilationUnit {
      * @return Returns the importedTypes.
      */
     public Set<FullyQualifiedJavaType> getImportedTypes() {
-        return Collections.unmodifiableSet(importedTypes);
+        return importedTypes;
     }
 
     /**

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/TopLevelEnumeration.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/TopLevelEnumeration.java
@@ -104,7 +104,7 @@ public class TopLevelEnumeration extends InnerEnum implements CompilationUnit {
      * @see org.mybatis.generator.api.dom.java.CompilationUnit#getImportedTypes()
      */
     public Set<FullyQualifiedJavaType> getImportedTypes() {
-        return Collections.unmodifiableSet(importedTypes);
+        return importedTypes;
     }
 
     /* (non-Javadoc)


### PR DESCRIPTION
org.mybatis.generator.api.dom.java.TopLevelClass
1.coding style reason
  directly expose  static import types 
```
    public Set<String> getStaticImports() {
        return this.staticImports;
    }
```
while expose readonly import types
```
    public Set<FullyQualifiedJavaType> getImportedTypes() {
        return Collections.unmodifiableSet(this.importedTypes);
    }
```
2.view and entity with baseEntity mixed senario
I have normal Entity which has common baseEntity 
 and view entity which has no common baseEntity. 
So I have to delete the imported baseEntity in my view entity ,but I can't directly manipulate the importedTypes
