### PR TITLE
Array imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@
 /core/mybatis-generator-systests-domtests/.settings
 /core/mybatis-generator-systests-domtests/target
 /.project
+.idea
+*.iml

--- a/core/mybatis-generator-core/pom.xml
+++ b/core/mybatis-generator-core/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2006-2016 the original author or authors.
+       Copyright 2006-2017 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/FullyQualifiedJavaType.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/FullyQualifiedJavaType.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2006-2016 the original author or authors.
+ *    Copyright 2006-2017 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -164,14 +164,14 @@ public class FullyQualifiedJavaType implements
         if (isExplicitlyImported()) {
             int index = baseShortName.indexOf('.');
             if (index == -1) {
-                answer.add(baseQualifiedName);
+                answer.add(calculateActualImport(baseQualifiedName));
             } else {
                 // an inner class is specified, only import the top
                 // level class
                 StringBuilder sb = new StringBuilder();
                 sb.append(packageName);
                 sb.append('.');
-                sb.append(baseShortName.substring(0, index));
+                sb.append(calculateActualImport(baseShortName.substring(0, index)));
                 answer.add(sb.toString());
             }
         }
@@ -180,6 +180,17 @@ public class FullyQualifiedJavaType implements
             answer.addAll(fqjt.getImportList());
         }
 
+        return answer;
+    }
+
+    private String calculateActualImport(String name) {
+        String answer = name;
+        if (this.isArray()) {
+            int index = name.indexOf("[");
+            if (index != -1) {
+                answer = name.substring(0, index);
+            }
+        }
         return answer;
     }
 

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/Interface.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/Interface.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2006-2016 the original author or authors.
+ *    Copyright 2006-2017 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/TopLevelClass.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/TopLevelClass.java
@@ -92,7 +92,7 @@ public class TopLevelClass extends InnerClass implements CompilationUnit {
                 && !importedType.getPackageName().equals(
                         getType().getPackageName())
                 && !importedType.getShortName().equals(getType().getShortName())) {
-                importedTypes.add(importedType);
+            importedTypes.add(importedType);
         }
     }
 

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/TopLevelClass.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/TopLevelClass.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2006-2016 the original author or authors.
+ *    Copyright 2006-2017 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -92,7 +92,7 @@ public class TopLevelClass extends InnerClass implements CompilationUnit {
                 && !importedType.getPackageName().equals(
                         getType().getPackageName())
                 && !importedType.getShortName().equals(getType().getShortName())) {
-            importedTypes.add(importedType);
+                importedTypes.add(importedType);
         }
     }
 

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/TopLevelEnumeration.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/TopLevelEnumeration.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2006-2016 the original author or authors.
+ *    Copyright 2006-2017 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/core/mybatis-generator-core/src/test/java/org/mybatis/generator/api/dom/java/FullyQualifiedJavaTypeTest.java
+++ b/core/mybatis-generator-core/src/test/java/org/mybatis/generator/api/dom/java/FullyQualifiedJavaTypeTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2006-2016 the original author or authors.
+ *    Copyright 2006-2017 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -270,5 +270,14 @@ public class FullyQualifiedJavaTypeTest {
         FullyQualifiedJavaType fqjt = new FullyQualifiedJavaType("java.util.List<String>[]");
         assertFalse(fqjt.isPrimitive());
         assertTrue(fqjt.isArray());
+    }
+
+    @Test
+    public void testComplexArrayWithoutGenerics() {
+        FullyQualifiedJavaType fqjt = new FullyQualifiedJavaType("java.util.List[]");
+        assertFalse(fqjt.isPrimitive());
+        assertTrue(fqjt.isArray());
+        assertTrue(fqjt.getImportList().contains("java.util.List"));
+        assertFalse(fqjt.getImportList().contains("java.util.List[]"));
     }
 }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2006-2016 the original author or authors.
+       Copyright 2006-2017 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fix while caculating imports, if the `FullyQualifiedJavaType` is an array and the array type is explicitly imported, then `[]` suffix is also imported