### PR TITLE
Allow plugins to change the mergeable attribute of an XML file

### DIFF
--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/GeneratedXmlFile.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/GeneratedXmlFile.java
@@ -101,4 +101,8 @@ public class GeneratedXmlFile extends GeneratedFile {
     public boolean isMergeable() {
         return isMergeable;
     }
+    
+    public void setMergeable(boolean isMergeable) {
+        this.isMergeable = isMergeable;
+    }
 }


### PR DESCRIPTION
This makes it possible to turn off the XML merger in a plugin.  This is an easier fix than #215.