### PR TITLE
Restore Java 6 usage where java 7 leaked and animal sniffer misses

### DIFF
--- a/core/mybatis-generator-core/src/test/java/org/mybatis/generator/api/dom/java/InterfaceTest.java
+++ b/core/mybatis-generator-core/src/test/java/org/mybatis/generator/api/dom/java/InterfaceTest.java
@@ -116,11 +116,11 @@ public class InterfaceTest {
         field.setInitializationString("\"one\"");
         interfaze.addField(field);
         
-        String expected = "package foo;" + System.lineSeparator()
-            + System.lineSeparator()
-            + "public interface Bar {" + System.lineSeparator()
-            + "    String EMPTY_STRING = \"\";" + System.lineSeparator()
-            + "    String ONE = \"one\";" + System.lineSeparator()
+        String expected = "package foo;" + System.getProperty("line.separator")
+            + System.getProperty("line.separator")
+            + "public interface Bar {" + System.getProperty("line.separator")
+            + "    String EMPTY_STRING = \"\";" + System.getProperty("line.separator")
+            + "    String ONE = \"one\";" + System.getProperty("line.separator")
             + "}";
 
         assertThat(interfaze.getFormattedContent(), is(expected));

--- a/core/mybatis-generator-maven-plugin/src/main/java/org/mybatis/generator/maven/SqlScriptRunner.java
+++ b/core/mybatis-generator-maven-plugin/src/main/java/org/mybatis/generator/maven/SqlScriptRunner.java
@@ -106,14 +106,18 @@ public class SqlScriptRunner {
             closeStatement(statement);
             connection.commit();
             br.close();
-        } catch (ReflectiveOperationException e) {
-            throw new MojoExecutionException("Reflection Exception", e);
+        } catch (ClassNotFoundException e) {
+            throw new MojoExecutionException("Class not found: " + e.getMessage());
         } catch (FileNotFoundException e) {
             throw new MojoExecutionException("File note found: " + sourceFile);
         } catch (SQLException e) {
             throw new MojoExecutionException("SqlException: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new MojoExecutionException("IOException: " + e.getMessage(), e);
+        } catch (InstantiationException e) {
+            throw new MojoExecutionException("InstantiationException: " + e.getMessage());
+        } catch (IllegalAccessException e) {
+            throw new MojoExecutionException("IllegalAccessException: " + e.getMessage());
         } finally {
             closeConnection(connection);
         }


### PR DESCRIPTION
Animal sniffer doesn't appear to catch proper code when on test side and doesn't appear to catch code without imports such as exceptions.  In both cases, eclipse catches this because the module is flagged to support java 6 entirely.  Fixed issue so code will properly not error in eclipse or if really using java 6.