### PR TITLE
Restore sub-package functionality

### DIFF
--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/FullyQualifiedTable.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/FullyQualifiedTable.java
@@ -397,4 +397,8 @@ public class FullyQualifiedTable {
             sb.append(endingDelimiter);
         }
     }
+
+    public String getDomainObjectSubPackage() {
+        return domainObjectSubPackage;
+    }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/IntrospectedTable.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/IntrospectedTable.java
@@ -827,6 +827,10 @@ public abstract class IntrospectedTable {
         if (stringHasValue(tableConfiguration.getMapperName())) {
             sb.append(tableConfiguration.getMapperName());
         } else {
+            if (stringHasValue(fullyQualifiedTable.getDomainObjectSubPackage())) {
+                sb.append(fullyQualifiedTable.getDomainObjectSubPackage());
+                sb.append('.');
+            }
             sb.append(fullyQualifiedTable.getDomainObjectName());
             sb.append("Mapper"); //$NON-NLS-1$
         }
@@ -838,6 +842,10 @@ public abstract class IntrospectedTable {
         if (stringHasValue(tableConfiguration.getSqlProviderName())) {
             sb.append(tableConfiguration.getSqlProviderName());
         } else {
+            if (stringHasValue(fullyQualifiedTable.getDomainObjectSubPackage())) {
+                sb.append(fullyQualifiedTable.getDomainObjectSubPackage());
+                sb.append('.');
+            }
             sb.append(fullyQualifiedTable.getDomainObjectName());
             sb.append("SqlProvider"); //$NON-NLS-1$
         }
@@ -901,6 +909,8 @@ public abstract class IntrospectedTable {
                 if (ind != -1) {
                     sb.append('.').append(mapperName.substring(0, ind));
                 }
+            } else if (stringHasValue(fullyQualifiedTable.getDomainObjectSubPackage())) {
+                sb.append('.').append(fullyQualifiedTable.getDomainObjectSubPackage());
             }
         }
 

--- a/core/mybatis-generator-core/src/test/resources/scripts/generatorConfig.xml
+++ b/core/mybatis-generator-core/src/test/resources/scripts/generatorConfig.xml
@@ -48,7 +48,7 @@
       <property name="enableSubPackages" value="true" />
     </javaClientGenerator>
 
-    <table tableName="FieldsOnly" />
+    <table tableName="FieldsOnly" domainObjectName="subpackage.Fieldsonly"/>
     <table tableName="PKOnly" />
     <table tableName="PKFields" alias="B" >
       <columnOverride column="wierd$Field" delimitedColumnName="true"/>
@@ -388,7 +388,7 @@
       <property name="enableSubPackages" value="true" />
     </javaClientGenerator>
 
-    <table tableName="FieldsOnly" />
+    <table tableName="FieldsOnly" domainObjectName="subpackage.Fieldsonly"/>
     <table tableName="PKOnly" />
     <table tableName="PKFields" alias="B" >
       <columnOverride column="wierd$Field" delimitedColumnName="true"/>

--- a/core/mybatis-generator-systests-ibatis2-java2/src/test/resources/mbg/test/ib2j2/hierarchical/SqlMapConfig.xml
+++ b/core/mybatis-generator-systests-ibatis2-java2/src/test/resources/mbg/test/ib2j2/hierarchical/SqlMapConfig.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2006-2016 the original author or authors.
+       Copyright 2006-2017 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@
   </transactionManager>
 
   <sqlMap resource="mbg/test/ib2j2/generated/hierarchical/xml/FIELDSBLOBS_SqlMap.xml" />
-  <sqlMap resource="mbg/test/ib2j2/generated/hierarchical/xml/FIELDSONLY_SqlMap.xml" />
+  <sqlMap resource="mbg/test/ib2j2/generated/hierarchical/xml/subpackage/FIELDSONLY_SqlMap.xml" />
   <sqlMap resource="mbg/test/ib2j2/generated/hierarchical/xml/PKBLOBS_SqlMap.xml" />
   <sqlMap resource="mbg/test/ib2j2/generated/hierarchical/xml/PKFIELDS_SqlMap.xml" />
   <sqlMap resource="mbg/test/ib2j2/generated/hierarchical/xml/PKFIELDSBLOBS_SqlMap.xml" />

--- a/core/mybatis-generator-systests-ibatis2-java5/src/test/resources/mbg/test/ib2j5/hierarchical/SqlMapConfig.xml
+++ b/core/mybatis-generator-systests-ibatis2-java5/src/test/resources/mbg/test/ib2j5/hierarchical/SqlMapConfig.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2006-2016 the original author or authors.
+       Copyright 2006-2017 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@
   <settings useStatementNamespaces="true" />
 
   <sqlMap resource="mbg/test/ib2j5/generated/hierarchical/xml/FIELDSBLOBS_SqlMap.xml" />
-  <sqlMap resource="mbg/test/ib2j5/generated/hierarchical/xml/FIELDSONLY_SqlMap.xml" />
+  <sqlMap resource="mbg/test/ib2j5/generated/hierarchical/xml/subpackage/FIELDSONLY_SqlMap.xml" />
   <sqlMap resource="mbg/test/ib2j5/generated/hierarchical/xml/PKBLOBS_SqlMap.xml" />
   <sqlMap resource="mbg/test/ib2j5/generated/hierarchical/xml/PKFIELDS_SqlMap.xml" />
   <sqlMap resource="mbg/test/ib2j5/generated/hierarchical/xml/PKFIELDSBLOBS_SqlMap.xml" />

--- a/core/mybatis-generator-systests-mybatis3/src/main/resources/generatorConfig.xml
+++ b/core/mybatis-generator-systests-mybatis3/src/main/resources/generatorConfig.xml
@@ -48,7 +48,7 @@
       <property name="enableSubPackages" value="true" />
     </javaClientGenerator>
 
-    <table tableName="FieldsOnly" />
+    <table tableName="FieldsOnly" domainObjectName="subpackage.Fieldsonly"/>
     <table tableName="PKOnly" />
     <table tableName="PKFields" alias="B" >
       <columnOverride column="wierd$Field" delimitedColumnName="true"/>
@@ -388,7 +388,7 @@
       <property name="enableSubPackages" value="true" />
     </javaClientGenerator>
 
-    <table tableName="FieldsOnly" />
+    <table tableName="FieldsOnly" domainObjectName="subpackage.Fieldsonly"/>
     <table tableName="PKOnly" />
     <table tableName="PKFields" alias="B" >
       <columnOverride column="wierd$Field" delimitedColumnName="true"/>

--- a/core/mybatis-generator-systests-mybatis3/src/test/java/mbg/test/mb3/annotated/flat/AbstractAnnotatedFlatTest.java
+++ b/core/mybatis-generator-systests-mybatis3/src/test/java/mbg/test/mb3/annotated/flat/AbstractAnnotatedFlatTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2006-2016 the original author or authors.
+ *    Copyright 2006-2017 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package mbg.test.mb3.annotated.flat;
 import mbg.test.mb3.AbstractTest;
 import mbg.test.mb3.generated.annotated.flat.mapper.AwfulTableMapper;
 import mbg.test.mb3.generated.annotated.flat.mapper.FieldsblobsMapper;
-import mbg.test.mb3.generated.annotated.flat.mapper.FieldsonlyMapper;
+import mbg.test.mb3.generated.annotated.flat.mapper.subpackage.FieldsonlyMapper;
 import mbg.test.mb3.generated.annotated.flat.mapper.PkblobsMapper;
 import mbg.test.mb3.generated.annotated.flat.mapper.PkfieldsMapper;
 import mbg.test.mb3.generated.annotated.flat.mapper.PkfieldsblobsMapper;

--- a/core/mybatis-generator-systests-mybatis3/src/test/java/mbg/test/mb3/annotated/flat/FlatJava5Test.java
+++ b/core/mybatis-generator-systests-mybatis3/src/test/java/mbg/test/mb3/annotated/flat/FlatJava5Test.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2006-2016 the original author or authors.
+ *    Copyright 2006-2017 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ import java.util.List;
 
 import mbg.test.mb3.generated.annotated.flat.mapper.AwfulTableMapper;
 import mbg.test.mb3.generated.annotated.flat.mapper.FieldsblobsMapper;
-import mbg.test.mb3.generated.annotated.flat.mapper.FieldsonlyMapper;
+import mbg.test.mb3.generated.annotated.flat.mapper.subpackage.FieldsonlyMapper;
 import mbg.test.mb3.generated.annotated.flat.mapper.PkblobsMapper;
 import mbg.test.mb3.generated.annotated.flat.mapper.PkfieldsMapper;
 import mbg.test.mb3.generated.annotated.flat.mapper.PkfieldsblobsMapper;
@@ -41,8 +41,8 @@ import mbg.test.mb3.generated.annotated.flat.model.AwfulTable;
 import mbg.test.mb3.generated.annotated.flat.model.AwfulTableExample;
 import mbg.test.mb3.generated.annotated.flat.model.Fieldsblobs;
 import mbg.test.mb3.generated.annotated.flat.model.FieldsblobsExample;
-import mbg.test.mb3.generated.annotated.flat.model.Fieldsonly;
-import mbg.test.mb3.generated.annotated.flat.model.FieldsonlyExample;
+import mbg.test.mb3.generated.annotated.flat.model.subpackage.Fieldsonly;
+import mbg.test.mb3.generated.annotated.flat.model.subpackage.FieldsonlyExample;
 import mbg.test.mb3.generated.annotated.flat.model.Pkblobs;
 import mbg.test.mb3.generated.annotated.flat.model.PkblobsExample;
 import mbg.test.mb3.generated.annotated.flat.model.Pkfields;

--- a/core/mybatis-generator-systests-mybatis3/src/test/java/mbg/test/mb3/annotated/flat/UpdateByExampleTest.java
+++ b/core/mybatis-generator-systests-mybatis3/src/test/java/mbg/test/mb3/annotated/flat/UpdateByExampleTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2006-2016 the original author or authors.
+ *    Copyright 2006-2017 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import java.util.List;
 
 import mbg.test.mb3.generated.annotated.flat.mapper.AwfulTableMapper;
 import mbg.test.mb3.generated.annotated.flat.mapper.FieldsblobsMapper;
-import mbg.test.mb3.generated.annotated.flat.mapper.FieldsonlyMapper;
+import mbg.test.mb3.generated.annotated.flat.mapper.subpackage.FieldsonlyMapper;
 import mbg.test.mb3.generated.annotated.flat.mapper.PkblobsMapper;
 import mbg.test.mb3.generated.annotated.flat.mapper.PkfieldsMapper;
 import mbg.test.mb3.generated.annotated.flat.mapper.PkfieldsblobsMapper;
@@ -34,8 +34,8 @@ import mbg.test.mb3.generated.annotated.flat.model.AwfulTable;
 import mbg.test.mb3.generated.annotated.flat.model.AwfulTableExample;
 import mbg.test.mb3.generated.annotated.flat.model.Fieldsblobs;
 import mbg.test.mb3.generated.annotated.flat.model.FieldsblobsExample;
-import mbg.test.mb3.generated.annotated.flat.model.Fieldsonly;
-import mbg.test.mb3.generated.annotated.flat.model.FieldsonlyExample;
+import mbg.test.mb3.generated.annotated.flat.model.subpackage.Fieldsonly;
+import mbg.test.mb3.generated.annotated.flat.model.subpackage.FieldsonlyExample;
 import mbg.test.mb3.generated.annotated.flat.model.Pkblobs;
 import mbg.test.mb3.generated.annotated.flat.model.PkblobsExample;
 import mbg.test.mb3.generated.annotated.flat.model.Pkfields;

--- a/core/mybatis-generator-systests-mybatis3/src/test/java/mbg/test/mb3/flat/FlatJava5Test.java
+++ b/core/mybatis-generator-systests-mybatis3/src/test/java/mbg/test/mb3/flat/FlatJava5Test.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2006-2016 the original author or authors.
+ *    Copyright 2006-2017 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -30,19 +30,21 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import org.apache.ibatis.session.RowBounds;
+import org.apache.ibatis.session.SqlSession;
+import org.junit.Test;
+
 import mbg.test.mb3.generated.flat.mapper.AwfulTableMapper;
 import mbg.test.mb3.generated.flat.mapper.FieldsblobsMapper;
-import mbg.test.mb3.generated.flat.mapper.FieldsonlyMapper;
 import mbg.test.mb3.generated.flat.mapper.PkblobsMapper;
 import mbg.test.mb3.generated.flat.mapper.PkfieldsMapper;
 import mbg.test.mb3.generated.flat.mapper.PkfieldsblobsMapper;
 import mbg.test.mb3.generated.flat.mapper.PkonlyMapper;
+import mbg.test.mb3.generated.flat.mapper.subpackage.FieldsonlyMapper;
 import mbg.test.mb3.generated.flat.model.AwfulTable;
 import mbg.test.mb3.generated.flat.model.AwfulTableExample;
 import mbg.test.mb3.generated.flat.model.Fieldsblobs;
 import mbg.test.mb3.generated.flat.model.FieldsblobsExample;
-import mbg.test.mb3.generated.flat.model.Fieldsonly;
-import mbg.test.mb3.generated.flat.model.FieldsonlyExample;
 import mbg.test.mb3.generated.flat.model.Pkblobs;
 import mbg.test.mb3.generated.flat.model.PkblobsExample;
 import mbg.test.mb3.generated.flat.model.Pkfields;
@@ -51,10 +53,8 @@ import mbg.test.mb3.generated.flat.model.Pkfieldsblobs;
 import mbg.test.mb3.generated.flat.model.PkfieldsblobsExample;
 import mbg.test.mb3.generated.flat.model.Pkonly;
 import mbg.test.mb3.generated.flat.model.PkonlyExample;
-
-import org.apache.ibatis.session.RowBounds;
-import org.apache.ibatis.session.SqlSession;
-import org.junit.Test;
+import mbg.test.mb3.generated.flat.model.subpackage.Fieldsonly;
+import mbg.test.mb3.generated.flat.model.subpackage.FieldsonlyExample;
 
 /**
  * @author Jeff Butler

--- a/core/mybatis-generator-systests-mybatis3/src/test/java/mbg/test/mb3/flat/UpdateByExampleTest.java
+++ b/core/mybatis-generator-systests-mybatis3/src/test/java/mbg/test/mb3/flat/UpdateByExampleTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2006-2016 the original author or authors.
+ *    Copyright 2006-2017 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -23,19 +23,20 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
+import org.apache.ibatis.session.SqlSession;
+import org.junit.Test;
+
 import mbg.test.mb3.generated.flat.mapper.AwfulTableMapper;
 import mbg.test.mb3.generated.flat.mapper.FieldsblobsMapper;
-import mbg.test.mb3.generated.flat.mapper.FieldsonlyMapper;
 import mbg.test.mb3.generated.flat.mapper.PkblobsMapper;
 import mbg.test.mb3.generated.flat.mapper.PkfieldsMapper;
 import mbg.test.mb3.generated.flat.mapper.PkfieldsblobsMapper;
 import mbg.test.mb3.generated.flat.mapper.PkonlyMapper;
+import mbg.test.mb3.generated.flat.mapper.subpackage.FieldsonlyMapper;
 import mbg.test.mb3.generated.flat.model.AwfulTable;
 import mbg.test.mb3.generated.flat.model.AwfulTableExample;
 import mbg.test.mb3.generated.flat.model.Fieldsblobs;
 import mbg.test.mb3.generated.flat.model.FieldsblobsExample;
-import mbg.test.mb3.generated.flat.model.Fieldsonly;
-import mbg.test.mb3.generated.flat.model.FieldsonlyExample;
 import mbg.test.mb3.generated.flat.model.Pkblobs;
 import mbg.test.mb3.generated.flat.model.PkblobsExample;
 import mbg.test.mb3.generated.flat.model.Pkfields;
@@ -44,9 +45,8 @@ import mbg.test.mb3.generated.flat.model.Pkfieldsblobs;
 import mbg.test.mb3.generated.flat.model.PkfieldsblobsExample;
 import mbg.test.mb3.generated.flat.model.Pkonly;
 import mbg.test.mb3.generated.flat.model.PkonlyExample;
-
-import org.apache.ibatis.session.SqlSession;
-import org.junit.Test;
+import mbg.test.mb3.generated.flat.model.subpackage.Fieldsonly;
+import mbg.test.mb3.generated.flat.model.subpackage.FieldsonlyExample;
 
 /**
  * 

--- a/core/mybatis-generator-systests-mybatis3/src/test/resources/mbg/test/mb3/flat/MapperConfig.xml
+++ b/core/mybatis-generator-systests-mybatis3/src/test/resources/mbg/test/mb3/flat/MapperConfig.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
 
-       Copyright 2006-2016 the original author or authors.
+       Copyright 2006-2017 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@
   <mappers>
     <mapper resource="mbg/test/mb3/generated/flat/xml/AwfulTableMapper.xml" />
     <mapper resource="mbg/test/mb3/generated/flat/xml/FieldsblobsMapper.xml" />
-    <mapper resource="mbg/test/mb3/generated/flat/xml/FieldsonlyMapper.xml" />
+    <mapper resource="mbg/test/mb3/generated/flat/xml/subpackage/FieldsonlyMapper.xml" />
     <mapper resource="mbg/test/mb3/generated/flat/xml/PkblobsMapper.xml" />
     <mapper resource="mbg/test/mb3/generated/flat/xml/PkfieldsMapper.xml" />
     <mapper resource="mbg/test/mb3/generated/flat/xml/PkfieldsblobsMapper.xml" />


### PR DESCRIPTION
If a sub-package is specified on the domainObjectName on a table
configuration, it should apply to all related objects unless overridden
some other way.  This is consistent with the documentation.  This is to
fix a regression introduced with #121.

This fixes #266 
