### PR TITLE
in oracle,   when data type is nvarchar2, match it to nvarchar  , whe…

### DIFF
--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/internal/db/DatabaseIntrospector.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/internal/db/DatabaseIntrospector.java
@@ -527,7 +527,24 @@ public class DatabaseIntrospector {
                     .createIntrospectedColumn(context);
 
             introspectedColumn.setTableAlias(tc.getAlias());
-            introspectedColumn.setJdbcType(rs.getInt("DATA_TYPE")); //$NON-NLS-1$
+            
+            int jdbcType = rs.getInt("DATA_TYPE");
+
+            // In oracle,
+            // when the data type is NVARCHAR2, match it to Types.NVARCHAR
+            // when the data type is VARCHAR2, match it to Types.VARCHAR
+            // which finally map to String
+            if (rs.getInt("DATA_TYPE") == Types.OTHER) {
+                String columnTypeName = rs.getString("TYPE_NAME");
+                if ("NVARCHAR2".equalsIgnoreCase(columnTypeName)) {
+                    jdbcType = Types.NVARCHAR;
+                } else if ("VARCHAR2".equalsIgnoreCase(columnTypeName)) {
+                    jdbcType = Types.VARCHAR;
+                }
+            }
+
+            introspectedColumn.setJdbcType(jdbcType); //$NON-NLS-1$
+
             introspectedColumn.setLength(rs.getInt("COLUMN_SIZE")); //$NON-NLS-1$
             introspectedColumn.setActualColumnName(rs.getString("COLUMN_NAME")); //$NON-NLS-1$
             introspectedColumn

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/internal/db/DatabaseIntrospector.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/internal/db/DatabaseIntrospector.java
@@ -24,10 +24,7 @@ import static org.mybatis.generator.internal.util.StringUtility.stringContainsSp
 import static org.mybatis.generator.internal.util.StringUtility.stringHasValue;
 import static org.mybatis.generator.internal.util.messages.Messages.getString;
 
-import java.sql.DatabaseMetaData;
-import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
-import java.sql.SQLException;
+import java.sql.*;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/internal/types/JavaTypeResolverDefaultImpl.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/internal/types/JavaTypeResolverDefaultImpl.java
@@ -178,14 +178,19 @@ public class JavaTypeResolverDefaultImpl implements JavaTypeResolver {
     protected FullyQualifiedJavaType calculateBigDecimalReplacement(IntrospectedColumn column, FullyQualifiedJavaType defaultType) {
         FullyQualifiedJavaType answer;
 
-        if (column.getScale() > 0 || column.getLength() > 18 || forceBigDecimals) {
-            answer = defaultType;
-        } else if (column.getLength() > 9) {
+        //If not forceBigDecimals,   do not use BigDecimals
+        if (forceBigDecimals) {
+            answer = new FullyQualifiedJavaType(BigDecimal.class.getName());
+        } else if (column.getScale() > 0 || column.getLength() > 18) {
+            answer = new FullyQualifiedJavaType(Double.class.getName());
+        } else if (column.getLength() > 9 || column.getLength() == 0) {
             answer = new FullyQualifiedJavaType(Long.class.getName());
         } else if (column.getLength() > 4) {
             answer = new FullyQualifiedJavaType(Integer.class.getName());
-        } else {
+        } else if (column.getLength() > 2) {
             answer = new FullyQualifiedJavaType(Short.class.getName());
+        } else {
+            answer = new FullyQualifiedJavaType(Byte.class.getName());
         }
 
         return answer;


### PR DESCRIPTION
…n data type is varchar2, match it to varchar, which finally match to String, instead of object.

when forceBigDecimals == false, if length > 18 or getScale() > 0 , use double instead of BigDecimal.