### PR TITLE
Add UnmergeableXmlMappersPlugin

### DIFF
--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/plugins/UnmergeableXmlMappersPlugin.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/plugins/UnmergeableXmlMappersPlugin.java
@@ -1,0 +1,46 @@
+/**
+ *    Copyright 2006-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.generator.plugins;
+
+import java.util.List;
+
+import org.mybatis.generator.api.GeneratedXmlFile;
+import org.mybatis.generator.api.IntrospectedTable;
+import org.mybatis.generator.api.PluginAdapter;
+
+/**
+ * This plugin marks generated XML mapper files as unmergeable.  This will cause the generator to either
+ * overwrite the files, or save the files under a new name depending on how the overwrite setting is configured.
+ *   
+ * This can be useful when comments are disabled so the normal XML merge won't work. 
+ * 
+ * @author Jeff Butler
+ * 
+ */
+public class UnmergeableXmlMappersPlugin extends PluginAdapter {
+
+    @Override
+    public boolean validate(List<String> warnings) {
+        return true;
+    }
+
+    @Override
+    public boolean sqlMapGenerated(GeneratedXmlFile sqlMap,
+            IntrospectedTable introspectedTable) {
+        sqlMap.setMergeable(false);
+        return true;
+    }
+}

--- a/core/mybatis-generator-core/src/site/xhtml/configreference/commentGenerator.xhtml
+++ b/core/mybatis-generator-core/src/site/xhtml/configreference/commentGenerator.xhtml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2006-2016 the original author or authors.
+       Copyright 2006-2018 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -93,6 +93,9 @@ specified with the <a href="property.html">&lt;property&gt;</a> child element:</
         </tr>
       </table>
      <p><b>Warning: </b> if you set this value to true, then all code merging will be disabled.</p>
+     <p>If you disable all comments, you might find the <code>UnmergeableXmlMappersPlugin</code> useful. It
+        will cause the generator to respect the overwrite flag for XML files.
+     </p>
     </td>
   </tr>
   <tr>

--- a/core/mybatis-generator-core/src/site/xhtml/reference/plugins.xhtml
+++ b/core/mybatis-generator-core/src/site/xhtml/reference/plugins.xhtml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2006-2016 the original author or authors.
+       Copyright 2006-2018 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -183,6 +183,13 @@ model classes.</p>
         fields of root class. It can be useful for tables with inheritance relation.</li>
 </ul>
 
+<h2>org.mybatis.generator.plugins.UnmergeableXmlMappersPlugin</h2>
+<p>This plugin will disable the XML merge function for generated mapper XML files.  This
+will cause the generator to respect the overwrite flag for XML files in the same way it does
+for Java files - if overwrite is true, then an existing file will be overwritten, else a
+new file will be written with a unique name.</p>
+<p>This plugin can be helpful if you disable all comments.</p>
+
 <h2>org.mybatis.generator.plugins.VirtualPrimaryKeyPlugin</h2>
 <p>This plugin can be used to specify columns that act as primary
 keys, even if they are not defined as primary key in the database.
@@ -200,5 +207,6 @@ returned from the database (typically all UPPERCASE).  For example:</p>
     &lt;property name="virtualKeyColumns" value="ID1, ID2" /&gt;
   &lt;/table&gt;
 </pre>
+
 </body>
 </html>

--- a/core/mybatis-generator-systests-mybatis3/src/main/resources/generatorConfig.xml
+++ b/core/mybatis-generator-systests-mybatis3/src/main/resources/generatorConfig.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2006-2017 the original author or authors.
+       Copyright 2006-2018 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -729,9 +729,10 @@
       <property name="searchString" value="Example$"/>
       <property name="replaceString" value="Criteria"/>
     </plugin>
+    <plugin type="org.mybatis.generator.plugins.UnmergeableXmlMappersPlugin" />
 
     <commentGenerator>
-      <property name="suppressDate" value="true"/>
+      <property name="suppressAllComments" value="true"/>
     </commentGenerator>
     
     <jdbcConnection driverClass="org.hsqldb.jdbcDriver"


### PR DESCRIPTION
This plugin will cause the generator to respect the overwrite flag for generated XML files.

This can be useful if all comments have been suppressed.  If you run the generator repeatedly and see that elements are duplicated in the generated XML, it is most likely caused by suppressing all generated comments.  In that case, adding this plugin will resolve the issue.

This fixes #302 and is also an answer for #196.
