### PR TITLE
Correctly handle optional Java Client Generator in DSQL Runtime

### DIFF
--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/IntrospectedTableMyBatis3DynamicSqlImpl.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/IntrospectedTableMyBatis3DynamicSqlImpl.java
@@ -43,6 +43,10 @@ public class IntrospectedTableMyBatis3DynamicSqlImpl extends IntrospectedTableMy
 
     @Override
     protected AbstractJavaClientGenerator createJavaClientGenerator() {
+        if (context.getJavaClientGeneratorConfiguration() == null) {
+            return null;
+        }
+
         return new DynamicSqlMapperGenerator();
     }
 

--- a/core/mybatis-generator-systests-mybatis3-java8/src/main/resources/generatorConfig.xml
+++ b/core/mybatis-generator-systests-mybatis3-java8/src/main/resources/generatorConfig.xml
@@ -122,4 +122,52 @@
       <columnOverride column="ID_PLUS2" isGeneratedAlways="true" />
     </table>
   </context>
+
+  <context id="dsql-modelonly" targetRuntime="MyBatis3DynamicSql">
+    <plugin type="org.mybatis.generator.plugins.EqualsHashCodePlugin" />
+    
+    <jdbcConnection driverClass="org.hsqldb.jdbcDriver"
+        connectionURL="jdbc:hsqldb:mem:aname"
+        userId="sa" />
+
+    <javaTypeResolver>
+      <property name="useJSR310Types" value="true"/>
+    </javaTypeResolver>
+
+    <javaModelGenerator targetPackage="mbg.test.mb3.generated.dsql.modelonly" targetProject="MAVEN">
+      <property name="enableSubPackages" value="true" />
+      <property name="trimStrings" value="true" />
+    </javaModelGenerator>
+
+    <table tableName="FieldsOnly" />
+    <table tableName="PKOnly">
+      <property name="immutable" value="true"/>
+    </table>
+    <table tableName="PKFields" alias="B" >
+      <property name="selectAllOrderByClause" value="ID1, ID2"/>
+      <columnOverride column="wierd$Field" delimitedColumnName="true"/>
+      <columnOverride column="stringBoolean" javaType="boolean" typeHandler="mbg.test.mb3.common.StringBooleanTypeHandler"/>
+    </table>
+    <table tableName="PKBlobs">
+      <property name="constructorBased" value="true"/>
+    </table>
+    <table tableName="PKFieldsBlobs" />
+    <table tableName="FieldsBlobs" />
+    <table tableName="awful table" alias="A">
+      <generatedKey column="CuStOmEr iD" sqlStatement="JDBC" />
+      <columnOverride column="first name" property="firstFirstName" />
+      <columnOverride column="first_name" property="secondFirstName" />
+      <columnOverride column="firstName" property="thirdFirstName" />
+      <columnOverride column="from" delimitedColumnName="true" >
+        <property name="fredswife" value="wilma"/>
+      </columnOverride>
+      <columnOverride column="active" javaType="boolean" />
+      <columnOverride column="_id1" delimitedColumnName="true" />
+      <columnOverride column="$id2" delimitedColumnName="true" />
+      <columnOverride column="id5_" delimitedColumnName="true" />
+      <columnOverride column="id6$" delimitedColumnName="true" />
+      <columnOverride column="id7$$" delimitedColumnName="true" />
+      <columnOverride column="class" property="dbClass" />
+    </table>
+  </context>
 </generatorConfiguration>


### PR DESCRIPTION
Fixes issue reported in #336 

Java Client Generator is optional.  If not specified, the generator will create model classes only.  With the DSQL runtime, this was causing a NPE.