### PR TITLE
Detect name collisions in MyBatisDynamicSQL Runtime

### DIFF
--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/DynamicSqlMapperGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/DynamicSqlMapperGenerator.java
@@ -121,6 +121,7 @@ public class DynamicSqlMapperGenerator extends AbstractJavaClientGenerator {
         fragmentGenerator = new FragmentGenerator.Builder()
                 .withIntrospectedTable(introspectedTable)
                 .withResultMapId(resultMapId)
+                .withTableFieldName(tableFieldName)
                 .build();
     }
 
@@ -161,6 +162,7 @@ public class DynamicSqlMapperGenerator extends AbstractJavaClientGenerator {
         BasicDeleteMethodGenerator generator = new BasicDeleteMethodGenerator.Builder()
                 .withContext(context)
                 .withIntrospectedTable(introspectedTable)
+                .withTableFieldName(tableFieldName)
                 .build();
         
         generate(interfaze, generator);
@@ -171,6 +173,7 @@ public class DynamicSqlMapperGenerator extends AbstractJavaClientGenerator {
                 .withContext(context)
                 .withFragmentGenerator(fragmentGenerator)
                 .withIntrospectedTable(introspectedTable)
+                .withTableFieldName(tableFieldName)
                 .withRecordType(recordType)
                 .build();
         
@@ -182,6 +185,7 @@ public class DynamicSqlMapperGenerator extends AbstractJavaClientGenerator {
                 .withContext(context)
                 .withFragmentGenerator(fragmentGenerator)
                 .withIntrospectedTable(introspectedTable)
+                .withTableFieldName(tableFieldName)
                 .withRecordType(recordType)
                 .withResultMapId(resultMapId)
                 .build();
@@ -194,6 +198,7 @@ public class DynamicSqlMapperGenerator extends AbstractJavaClientGenerator {
                 .withContext(context)
                 .withFragmentGenerator(fragmentGenerator)
                 .withIntrospectedTable(introspectedTable)
+                .withTableFieldName(tableFieldName)
                 .withRecordType(recordType)
                 .build();
         
@@ -204,6 +209,7 @@ public class DynamicSqlMapperGenerator extends AbstractJavaClientGenerator {
         BasicUpdateMethodGenerator generator = new BasicUpdateMethodGenerator.Builder()
                 .withContext(context)
                 .withIntrospectedTable(introspectedTable)
+                .withTableFieldName(tableFieldName)
                 .build();
         
         generate(interfaze, generator);
@@ -347,7 +353,7 @@ public class DynamicSqlMapperGenerator extends AbstractJavaClientGenerator {
     }
 
     private TopLevelClass getSupportClass() {
-        return DynamicSqlSupportClassGenerator.of(introspectedTable, context.getCommentGenerator()).generate();
+        return DynamicSqlSupportClassGenerator.of(introspectedTable, context.getCommentGenerator(), warnings).generate();
     }
 
     private void generate(Interface interfaze, AbstractMethodGenerator generator) {

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/DynamicSqlModelGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/DynamicSqlModelGenerator.java
@@ -38,7 +38,7 @@ import org.mybatis.generator.codegen.AbstractJavaGenerator;
 import org.mybatis.generator.codegen.RootClassInfo;
 
 /**
- * This model generator builds a flat model qith default constructor and getters/setters.
+ * This model generator builds a flat model with default constructor and getters/setters.
  * It does not support the immutable model, or constructor based attributes.
  * 
  * @author Jeff Butler

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/DynamicSqlSupportClassGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/DynamicSqlSupportClassGenerator.java
@@ -31,10 +31,12 @@ import org.mybatis.generator.api.dom.java.Method;
 import org.mybatis.generator.api.dom.java.TopLevelClass;
 import org.mybatis.generator.internal.util.JavaBeansUtil;
 import org.mybatis.generator.internal.util.StringUtility;
+import org.mybatis.generator.internal.util.messages.Messages;
 
 public class DynamicSqlSupportClassGenerator {
     private IntrospectedTable introspectedTable;
     private CommentGenerator commentGenerator;
+    private List<String> warnings;
     
     private DynamicSqlSupportClassGenerator() {
         super();
@@ -110,17 +112,24 @@ public class DynamicSqlSupportClassGenerator {
         FullyQualifiedJavaType fieldType = calculateFieldType(column);
         String fieldName = column.getJavaProperty();
         
-        // tlc field
-        Field field = new Field(fieldName, fieldType);
-        field.setVisibility(JavaVisibility.PUBLIC);
-        field.setStatic(true);
-        field.setFinal(true);
-        field.setInitializationString(tableFieldName + "." + fieldName); //$NON-NLS-1$
-        commentGenerator.addFieldAnnotation(field, introspectedTable, column, topLevelClass.getImportedTypes());
-        topLevelClass.addField(field);
+        if (fieldName.equals(tableFieldName)) {
+            // name collision, skip the shortcut field
+            warnings.add(
+                    Messages.getString("Warning.29", //$NON-NLS-1$
+                            fieldName, topLevelClass.getType().getFullyQualifiedName()));
+        } else {
+            // shortcut field
+            Field field = new Field(fieldName, fieldType);
+            field.setVisibility(JavaVisibility.PUBLIC);
+            field.setStatic(true);
+            field.setFinal(true);
+            field.setInitializationString(tableFieldName + "." + fieldName); //$NON-NLS-1$
+            commentGenerator.addFieldAnnotation(field, introspectedTable, column, topLevelClass.getImportedTypes());
+            topLevelClass.addField(field);
+        }
         
         // inner class field
-        field = new Field(fieldName, fieldType);
+        Field field = new Field(fieldName, fieldType);
         field.setVisibility(JavaVisibility.PUBLIC);
         field.setFinal(true);
         field.setInitializationString(calculateInnerInitializationString(column));
@@ -153,10 +162,11 @@ public class DynamicSqlSupportClassGenerator {
         return initializationString.toString();
     }
     
-    public static DynamicSqlSupportClassGenerator of(IntrospectedTable introspectedTable, CommentGenerator commentGenerator) {
+    public static DynamicSqlSupportClassGenerator of(IntrospectedTable introspectedTable, CommentGenerator commentGenerator, List<String> warnings) {
         DynamicSqlSupportClassGenerator generator = new DynamicSqlSupportClassGenerator();
         generator.introspectedTable = introspectedTable;
         generator.commentGenerator = commentGenerator;
+        generator.warnings = warnings;
         return generator;
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/elements/AbstractMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/elements/AbstractMethodGenerator.java
@@ -15,6 +15,7 @@
  */
 package org.mybatis.generator.runtime.dynamic.sql.elements;
 
+import org.mybatis.generator.api.IntrospectedColumn;
 import org.mybatis.generator.api.IntrospectedTable;
 import org.mybatis.generator.api.dom.java.Interface;
 import org.mybatis.generator.api.dom.java.Method;
@@ -24,10 +25,25 @@ import org.mybatis.generator.config.Context;
 public abstract class AbstractMethodGenerator {
     protected Context context;
     protected IntrospectedTable introspectedTable;
+    protected String tableFieldName;
     
     protected AbstractMethodGenerator(BaseBuilder<?, ?> builder) {
         context = builder.context;
         introspectedTable = builder.introspectedTable;
+        tableFieldName = builder.tableFieldName;
+    }
+
+    protected String calculateFieldName(IntrospectedColumn column) {
+        return calculateFieldName(tableFieldName, column);
+    }
+    
+    public static String calculateFieldName(String tableFieldName, IntrospectedColumn column) {
+        String fieldName = column.getJavaProperty();
+        if (fieldName.equals(tableFieldName)) {
+            // name collision, no shortcut generated
+            fieldName = tableFieldName + "." + fieldName; //$NON-NLS-1$
+        }
+        return fieldName;
     }
     
     protected void acceptParts(MethodAndImports.Builder builder, Method method, MethodParts methodParts) {
@@ -50,6 +66,7 @@ public abstract class AbstractMethodGenerator {
     public abstract static class BaseBuilder<T extends BaseBuilder<T, R>, R> {
         private Context context;
         private IntrospectedTable introspectedTable;
+        private String tableFieldName;
         
         public T withContext(Context context) {
             this.context = context;
@@ -58,6 +75,11 @@ public abstract class AbstractMethodGenerator {
         
         public T withIntrospectedTable(IntrospectedTable introspectedTable) {
             this.introspectedTable = introspectedTable;
+            return getThis();
+        }
+
+        public T withTableFieldName(String tableFieldName) {
+            this.tableFieldName = tableFieldName;
             return getThis();
         }
 

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/elements/CountByExampleMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/elements/CountByExampleMethodGenerator.java
@@ -24,11 +24,8 @@ import org.mybatis.generator.api.dom.java.Method;
 
 public class CountByExampleMethodGenerator extends AbstractMethodGenerator {
 
-    private String tableFieldName;
-    
     private CountByExampleMethodGenerator(Builder builder) {
         super(builder);
-        this.tableFieldName = builder.tableFieldName;
     }
     
     @Override
@@ -64,13 +61,6 @@ public class CountByExampleMethodGenerator extends AbstractMethodGenerator {
     }
 
     public static class Builder extends BaseBuilder<Builder, CountByExampleMethodGenerator> {
-        private String tableFieldName;
-        
-        public Builder withTableFieldName(String tableFieldName) {
-            this.tableFieldName = tableFieldName;
-            return this;
-        }
-        
         @Override
         public Builder getThis() {
             return this;

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/elements/DeleteByExampleMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/elements/DeleteByExampleMethodGenerator.java
@@ -23,11 +23,9 @@ import org.mybatis.generator.api.dom.java.Interface;
 import org.mybatis.generator.api.dom.java.Method;
 
 public class DeleteByExampleMethodGenerator extends AbstractMethodGenerator {
-    private String tableFieldName;
     
     private DeleteByExampleMethodGenerator(Builder builder) {
         super(builder);
-        tableFieldName = builder.tableFieldName;
     }
 
     @Override
@@ -61,13 +59,6 @@ public class DeleteByExampleMethodGenerator extends AbstractMethodGenerator {
 
     public static class Builder extends BaseBuilder<Builder, DeleteByExampleMethodGenerator> {
 
-        private String tableFieldName;
-        
-        public Builder withTableFieldName(String tableFIeldName) {
-            this.tableFieldName = tableFIeldName;
-            return this;
-        }
-        
         @Override
         public Builder getThis() {
             return this;

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/elements/DeleteByPrimaryKeyMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/elements/DeleteByPrimaryKeyMethodGenerator.java
@@ -25,12 +25,10 @@ import org.mybatis.generator.api.dom.java.Parameter;
 
 public class DeleteByPrimaryKeyMethodGenerator extends AbstractMethodGenerator {
     
-    private String tableFieldName;
     private FragmentGenerator fragmentGenerator;
     
     private DeleteByPrimaryKeyMethodGenerator(Builder builder) {
         super(builder);
-        tableFieldName = builder.tableFieldName;
         fragmentGenerator = builder.fragmentGenerator;
     }
 
@@ -76,13 +74,7 @@ public class DeleteByPrimaryKeyMethodGenerator extends AbstractMethodGenerator {
 
     public static class Builder extends BaseBuilder<Builder, DeleteByPrimaryKeyMethodGenerator> {
         
-        private String tableFieldName;
         private FragmentGenerator fragmentGenerator;
-        
-        public Builder withTableFieldName(String tableFieldName) {
-            this.tableFieldName = tableFieldName;
-            return this;
-        }
         
         public Builder withFragmentGenerator(FragmentGenerator fragmentGenerator) {
             this.fragmentGenerator = fragmentGenerator;

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/elements/FragmentGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/elements/FragmentGenerator.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.mybatis.generator.api.IntrospectedColumn;
 import org.mybatis.generator.api.IntrospectedTable;
@@ -36,25 +37,18 @@ public class FragmentGenerator {
 
     private IntrospectedTable introspectedTable;
     private String resultMapId;
+    private String tableFieldName;
     
     private FragmentGenerator(Builder builder) {
         this.introspectedTable = builder.introspectedTable;
         this.resultMapId = builder.resultMapId;
+        tableFieldName = builder.tableFieldName;
     }
     
     public String getSelectList() {
-        StringBuilder sb = new StringBuilder();
-        boolean first = true;
-        for (IntrospectedColumn column : introspectedTable.getAllColumns()) {
-            if (first) {
-                first = false;
-            } else {
-                sb.append(", "); //$NON-NLS-1$
-            }
-            sb.append(column.getJavaProperty());
-        }
-        
-        return sb.toString();
+        return introspectedTable.getAllColumns().stream()
+                .map(c -> AbstractMethodGenerator.calculateFieldName(tableFieldName, c))
+                .collect(Collectors.joining(", ")); //$NON-NLS-1$
     }
     
     public MethodParts getPrimaryKeyWhereClauseAndParameters() {
@@ -62,15 +56,16 @@ public class FragmentGenerator {
         
         boolean first = true;
         for (IntrospectedColumn column : introspectedTable.getPrimaryKeyColumns()) {
+            String fieldName = AbstractMethodGenerator.calculateFieldName(tableFieldName, column);
             builder.withImport(column.getFullyQualifiedJavaType());
             builder.withParameter(new Parameter(column.getFullyQualifiedJavaType(), column.getJavaProperty() + "_")); //$NON-NLS-1$
             if (first) {
-                builder.withBodyLine("        .where(" + column.getJavaProperty() //$NON-NLS-1$
+                builder.withBodyLine("        .where(" + fieldName //$NON-NLS-1$
                         + ", isEqualTo(" + column.getJavaProperty() //$NON-NLS-1$
                         + "_))"); //$NON-NLS-1$
                 first = false;
             } else {
-                builder.withBodyLine("        .and(" + column.getJavaProperty() //$NON-NLS-1$
+                builder.withBodyLine("        .and(" + fieldName //$NON-NLS-1$
                         + ", isEqualTo(" + column.getJavaProperty() //$NON-NLS-1$
                         + "_))"); //$NON-NLS-1$
             }
@@ -84,14 +79,15 @@ public class FragmentGenerator {
         
         boolean first = true;
         for (IntrospectedColumn column : introspectedTable.getPrimaryKeyColumns()) {
+            String fieldName = AbstractMethodGenerator.calculateFieldName(tableFieldName, column);
             String methodName = JavaBeansUtil.getGetterMethodName(column.getJavaProperty(), column.getFullyQualifiedJavaType());
             if (first) {
-                lines.add("        .where(" + column.getJavaProperty() //$NON-NLS-1$
+                lines.add("        .where(" + fieldName //$NON-NLS-1$
                         + ", isEqualTo(record::" + methodName //$NON-NLS-1$
                         + "))"); //$NON-NLS-1$
                 first = false;
             } else {
-                lines.add("        .and(" + column.getJavaProperty() //$NON-NLS-1$
+                lines.add("        .and(" + fieldName //$NON-NLS-1$
                         + ", isEqualTo(record::" + methodName //$NON-NLS-1$
                         + "))"); //$NON-NLS-1$
             }
@@ -285,8 +281,9 @@ public class FragmentGenerator {
         Iterator<IntrospectedColumn> iter = columns.iterator();
         while (iter.hasNext()) {
             IntrospectedColumn column = iter.next();
+            String fieldName = AbstractMethodGenerator.calculateFieldName(tableFieldName, column);
             String methodName = JavaBeansUtil.getGetterMethodName(column.getJavaProperty(), column.getFullyQualifiedJavaType());
-            String line = "        .set(" + column.getJavaProperty() //$NON-NLS-1$
+            String line = "        .set(" + fieldName //$NON-NLS-1$
                     + ").equalTo(record::" + methodName //$NON-NLS-1$
                     + ")"; //$NON-NLS-1$
             if (terminate && !iter.hasNext()) {
@@ -304,8 +301,9 @@ public class FragmentGenerator {
         Iterator<IntrospectedColumn> iter = columns.iterator();
         while (iter.hasNext()) {
             IntrospectedColumn column = iter.next();
+            String fieldName = AbstractMethodGenerator.calculateFieldName(tableFieldName, column);
             String methodName = JavaBeansUtil.getGetterMethodName(column.getJavaProperty(), column.getFullyQualifiedJavaType());
-            String line = "        .set(" + column.getJavaProperty() //$NON-NLS-1$
+            String line = "        .set(" + fieldName //$NON-NLS-1$
                     + ").equalToWhenPresent(record::" //$NON-NLS-1$
                     + methodName + ")"; //$NON-NLS-1$
             if (terminate && !iter.hasNext()) {
@@ -319,6 +317,7 @@ public class FragmentGenerator {
     public static class Builder {
         private IntrospectedTable introspectedTable;
         private String resultMapId;
+        private String tableFieldName;
         
         public Builder withIntrospectedTable(IntrospectedTable introspectedTable) {
             this.introspectedTable = introspectedTable;
@@ -327,6 +326,11 @@ public class FragmentGenerator {
         
         public Builder withResultMapId(String resultMapId) {
             this.resultMapId = resultMapId;
+            return this;
+        }
+        
+        public Builder withTableFieldName(String tableFieldName) {
+            this.tableFieldName = tableFieldName;
             return this;
         }
         

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/elements/InsertMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/elements/InsertMethodGenerator.java
@@ -27,12 +27,10 @@ import org.mybatis.generator.api.dom.java.Parameter;
 import org.mybatis.generator.codegen.mybatis3.ListUtilities;
 
 public class InsertMethodGenerator extends AbstractMethodGenerator {
-    private String tableFieldName;
     private FullyQualifiedJavaType recordType;
     
     private InsertMethodGenerator(Builder builder) {
         super(builder);
-        tableFieldName = builder.tableFieldName;
         recordType = builder.recordType;
     }
 
@@ -59,7 +57,9 @@ public class InsertMethodGenerator extends AbstractMethodGenerator {
         
         List<IntrospectedColumn> columns = ListUtilities.removeIdentityAndGeneratedAlwaysColumns(introspectedTable.getAllColumns());
         for (IntrospectedColumn column : columns) {
-            method.addBodyLine("        .map(" + column.getJavaProperty() //$NON-NLS-1$
+            String fieldName = calculateFieldName(column);
+            
+            method.addBodyLine("        .map(" + fieldName //$NON-NLS-1$
                     + ").toProperty(\"" + column.getJavaProperty() //$NON-NLS-1$
                     + "\")"); //$NON-NLS-1$
         }
@@ -78,13 +78,7 @@ public class InsertMethodGenerator extends AbstractMethodGenerator {
     }
 
     public static class Builder extends BaseBuilder<Builder, InsertMethodGenerator> {
-        private String tableFieldName;
         private FullyQualifiedJavaType recordType;
-        
-        public Builder withTableFieldName(String tableFieldName) {
-            this.tableFieldName = tableFieldName;
-            return this;
-        }
         
         public Builder withRecordType(FullyQualifiedJavaType recordType) {
             this.recordType = recordType;

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/elements/InsertSelectiveMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/elements/InsertSelectiveMethodGenerator.java
@@ -29,12 +29,10 @@ import org.mybatis.generator.internal.util.JavaBeansUtil;
 
 public class InsertSelectiveMethodGenerator extends AbstractMethodGenerator {
     private FullyQualifiedJavaType recordType;
-    private String tableFieldName;
     
     private InsertSelectiveMethodGenerator(Builder builder) {
         super(builder);
         recordType = builder.recordType;
-        tableFieldName = builder.tableFieldName;
     }
 
     @Override
@@ -60,13 +58,14 @@ public class InsertSelectiveMethodGenerator extends AbstractMethodGenerator {
         
         List<IntrospectedColumn> columns = ListUtilities.removeIdentityAndGeneratedAlwaysColumns(introspectedTable.getAllColumns());
         for (IntrospectedColumn column : columns) {
+            String fieldName = calculateFieldName(column);
             if (column.isSequenceColumn()) {
-                method.addBodyLine("        .map(" + column.getJavaProperty() //$NON-NLS-1$
+                method.addBodyLine("        .map(" + fieldName //$NON-NLS-1$
                         + ").toProperty(\"" + column.getJavaProperty() //$NON-NLS-1$
                         + "\")"); //$NON-NLS-1$
             } else {
                 String methodName = JavaBeansUtil.getGetterMethodName(column.getJavaProperty(), column.getFullyQualifiedJavaType());
-                method.addBodyLine("        .map(" + column.getJavaProperty() //$NON-NLS-1$
+                method.addBodyLine("        .map(" + fieldName //$NON-NLS-1$
                         + ").toPropertyWhenPresent(\"" + column.getJavaProperty() //$NON-NLS-1$
                         + "\", record::" + methodName //$NON-NLS-1$
                         + ")"); //$NON-NLS-1$
@@ -88,18 +87,12 @@ public class InsertSelectiveMethodGenerator extends AbstractMethodGenerator {
 
     public static class Builder extends BaseBuilder<Builder, InsertSelectiveMethodGenerator> {
         private FullyQualifiedJavaType recordType;
-        private String tableFieldName;
         
         public Builder withRecordType(FullyQualifiedJavaType recordType) {
             this.recordType = recordType;
             return this;
         }
         
-        public Builder withTableFieldName(String tableFieldName) {
-            this.tableFieldName = tableFieldName;
-            return this;
-        }
-
         @Override
         public Builder getThis() {
             return this;

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/elements/SelectByExampleMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/elements/SelectByExampleMethodGenerator.java
@@ -24,13 +24,11 @@ import org.mybatis.generator.api.dom.java.Method;
 
 public class SelectByExampleMethodGenerator extends AbstractMethodGenerator {
     private FullyQualifiedJavaType recordType;
-    private String tableFieldName;
     private FragmentGenerator fragmentGenerator;
     
     private SelectByExampleMethodGenerator(Builder builder) {
         super(builder);
         recordType = builder.recordType;
-        tableFieldName = builder.tableFieldName;
         fragmentGenerator = builder.fragmentGenerator;
     }
 
@@ -76,7 +74,6 @@ public class SelectByExampleMethodGenerator extends AbstractMethodGenerator {
 
     public static class Builder extends BaseBuilder<Builder, SelectByExampleMethodGenerator> {
         private FullyQualifiedJavaType recordType;
-        private String tableFieldName;
         private FragmentGenerator fragmentGenerator;
         
         public Builder withRecordType(FullyQualifiedJavaType recordType) {
@@ -84,11 +81,6 @@ public class SelectByExampleMethodGenerator extends AbstractMethodGenerator {
             return this;
         }
         
-        public Builder withTableFieldName(String tableFieldName) {
-            this.tableFieldName = tableFieldName;
-            return this;
-        }
-
         public Builder withFragmentGenerator(FragmentGenerator fragmentGenerator) {
             this.fragmentGenerator = fragmentGenerator;
             return this;

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/elements/SelectByPrimaryKeyMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/elements/SelectByPrimaryKeyMethodGenerator.java
@@ -24,13 +24,11 @@ import org.mybatis.generator.api.dom.java.Method;
 
 public class SelectByPrimaryKeyMethodGenerator extends AbstractMethodGenerator {
     private FullyQualifiedJavaType recordType;
-    private String tableFieldName;
     private FragmentGenerator fragmentGenerator;
     
     private SelectByPrimaryKeyMethodGenerator(Builder builder) {
         super(builder);
         recordType = builder.recordType;
-        tableFieldName = builder.tableFieldName;
         fragmentGenerator = builder.fragmentGenerator;
     }
 
@@ -78,7 +76,6 @@ public class SelectByPrimaryKeyMethodGenerator extends AbstractMethodGenerator {
 
     public static class Builder extends BaseBuilder<Builder, SelectByPrimaryKeyMethodGenerator> {
         private FullyQualifiedJavaType recordType;
-        private String tableFieldName;
         private FragmentGenerator fragmentGenerator;
         
         public Builder withRecordType(FullyQualifiedJavaType recordType) {
@@ -86,11 +83,6 @@ public class SelectByPrimaryKeyMethodGenerator extends AbstractMethodGenerator {
             return this;
         }
         
-        public Builder withTableFieldName(String tableFieldName) {
-            this.tableFieldName = tableFieldName;
-            return this;
-        }
-
         public Builder withFragmentGenerator(FragmentGenerator fragmentGenerator) {
             this.fragmentGenerator = fragmentGenerator;
             return this;

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/elements/SelectDistinctByExampleMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/elements/SelectDistinctByExampleMethodGenerator.java
@@ -24,13 +24,11 @@ import org.mybatis.generator.api.dom.java.Method;
 
 public class SelectDistinctByExampleMethodGenerator extends AbstractMethodGenerator {
     private FullyQualifiedJavaType recordType;
-    private String tableFieldName;
     private FragmentGenerator fragmentGenerator;
     
     private SelectDistinctByExampleMethodGenerator(Builder builder) {
         super(builder);
         recordType = builder.recordType;
-        tableFieldName = builder.tableFieldName;
         fragmentGenerator = builder.fragmentGenerator;
     }
 
@@ -76,7 +74,6 @@ public class SelectDistinctByExampleMethodGenerator extends AbstractMethodGenera
 
     public static class Builder extends BaseBuilder<Builder, SelectDistinctByExampleMethodGenerator> {
         private FullyQualifiedJavaType recordType;
-        private String tableFieldName;
         private FragmentGenerator fragmentGenerator;
         
         public Builder withRecordType(FullyQualifiedJavaType recordType) {
@@ -84,11 +81,6 @@ public class SelectDistinctByExampleMethodGenerator extends AbstractMethodGenera
             return this;
         }
         
-        public Builder withTableFieldName(String tableFieldName) {
-            this.tableFieldName = tableFieldName;
-            return this;
-        }
-
         public Builder withFragmentGenerator(FragmentGenerator fragmentGenerator) {
             this.fragmentGenerator = fragmentGenerator;
             return this;

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/elements/UpdateByExampleMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/elements/UpdateByExampleMethodGenerator.java
@@ -25,13 +25,11 @@ import org.mybatis.generator.api.dom.java.Parameter;
 
 public class UpdateByExampleMethodGenerator extends AbstractMethodGenerator {
     private FullyQualifiedJavaType recordType;
-    private String tableFieldName;
     private FragmentGenerator fragmentGenerator;
     
     private UpdateByExampleMethodGenerator(Builder builder) {
         super(builder);
         recordType = builder.recordType;
-        tableFieldName = builder.tableFieldName;
         fragmentGenerator = builder.fragmentGenerator;
     }
 
@@ -72,7 +70,6 @@ public class UpdateByExampleMethodGenerator extends AbstractMethodGenerator {
 
     public static class Builder extends BaseBuilder<Builder, UpdateByExampleMethodGenerator> {
         private FullyQualifiedJavaType recordType;
-        private String tableFieldName;
         private FragmentGenerator fragmentGenerator;
         
         public Builder withRecordType(FullyQualifiedJavaType recordType) {
@@ -80,11 +77,6 @@ public class UpdateByExampleMethodGenerator extends AbstractMethodGenerator {
             return this;
         }
         
-        public Builder withTableFieldName(String tableFieldName) {
-            this.tableFieldName = tableFieldName;
-            return this;
-        }
-
         public Builder withFragmentGenerator(FragmentGenerator fragmentGenerator) {
             this.fragmentGenerator = fragmentGenerator;
             return this;

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/elements/UpdateByExampleSelectiveMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/elements/UpdateByExampleSelectiveMethodGenerator.java
@@ -25,13 +25,11 @@ import org.mybatis.generator.api.dom.java.Parameter;
 
 public class UpdateByExampleSelectiveMethodGenerator extends AbstractMethodGenerator {
     private FullyQualifiedJavaType recordType;
-    private String tableFieldName;
     private FragmentGenerator fragmentGenerator;
     
     private UpdateByExampleSelectiveMethodGenerator(Builder builder) {
         super(builder);
         recordType = builder.recordType;
-        tableFieldName = builder.tableFieldName;
         fragmentGenerator = builder.fragmentGenerator;
     }
 
@@ -71,7 +69,6 @@ public class UpdateByExampleSelectiveMethodGenerator extends AbstractMethodGener
 
     public static class Builder extends BaseBuilder<Builder, UpdateByExampleSelectiveMethodGenerator> {
         private FullyQualifiedJavaType recordType;
-        private String tableFieldName;
         private FragmentGenerator fragmentGenerator;
         
         public Builder withRecordType(FullyQualifiedJavaType recordType) {
@@ -79,11 +76,6 @@ public class UpdateByExampleSelectiveMethodGenerator extends AbstractMethodGener
             return this;
         }
         
-        public Builder withTableFieldName(String tableFieldName) {
-            this.tableFieldName = tableFieldName;
-            return this;
-        }
-
         public Builder withFragmentGenerator(FragmentGenerator fragmentGenerator) {
             this.fragmentGenerator = fragmentGenerator;
             return this;

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/elements/UpdateByPrimaryKeyMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/elements/UpdateByPrimaryKeyMethodGenerator.java
@@ -25,13 +25,11 @@ import org.mybatis.generator.api.dom.java.Parameter;
 
 public class UpdateByPrimaryKeyMethodGenerator extends AbstractMethodGenerator {
     private FullyQualifiedJavaType recordType;
-    private String tableFieldName;
     private FragmentGenerator fragmentGenerator;
     
     private UpdateByPrimaryKeyMethodGenerator(Builder builder) {
         super(builder);
         recordType = builder.recordType;
-        tableFieldName = builder.tableFieldName;
         fragmentGenerator = builder.fragmentGenerator;
     }
 
@@ -73,7 +71,6 @@ public class UpdateByPrimaryKeyMethodGenerator extends AbstractMethodGenerator {
 
     public static class Builder extends BaseBuilder<Builder, UpdateByPrimaryKeyMethodGenerator> {
         private FullyQualifiedJavaType recordType;
-        private String tableFieldName;
         private FragmentGenerator fragmentGenerator;
         
         public Builder withRecordType(FullyQualifiedJavaType recordType) {
@@ -81,11 +78,6 @@ public class UpdateByPrimaryKeyMethodGenerator extends AbstractMethodGenerator {
             return this;
         }
         
-        public Builder withTableFieldName(String tableFieldName) {
-            this.tableFieldName = tableFieldName;
-            return this;
-        }
-
         public Builder withFragmentGenerator(FragmentGenerator fragmentGenerator) {
             this.fragmentGenerator = fragmentGenerator;
             return this;

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/elements/UpdateByPrimaryKeySelectiveMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/elements/UpdateByPrimaryKeySelectiveMethodGenerator.java
@@ -25,13 +25,11 @@ import org.mybatis.generator.api.dom.java.Parameter;
 
 public class UpdateByPrimaryKeySelectiveMethodGenerator extends AbstractMethodGenerator {
     private FullyQualifiedJavaType recordType;
-    private String tableFieldName;
     private FragmentGenerator fragmentGenerator;
     
     private UpdateByPrimaryKeySelectiveMethodGenerator(Builder builder) {
         super(builder);
         recordType = builder.recordType;
-        tableFieldName = builder.tableFieldName;
         fragmentGenerator = builder.fragmentGenerator;
     }
 
@@ -72,7 +70,6 @@ public class UpdateByPrimaryKeySelectiveMethodGenerator extends AbstractMethodGe
 
     public static class Builder extends BaseBuilder<Builder, UpdateByPrimaryKeySelectiveMethodGenerator> {
         private FullyQualifiedJavaType recordType;
-        private String tableFieldName;
         private FragmentGenerator fragmentGenerator;
         
         public Builder withRecordType(FullyQualifiedJavaType recordType) {
@@ -80,11 +77,6 @@ public class UpdateByPrimaryKeySelectiveMethodGenerator extends AbstractMethodGe
             return this;
         }
         
-        public Builder withTableFieldName(String tableFieldName) {
-            this.tableFieldName = tableFieldName;
-            return this;
-        }
-
         public Builder withFragmentGenerator(FragmentGenerator fragmentGenerator) {
             this.fragmentGenerator = fragmentGenerator;
             return this;

--- a/core/mybatis-generator-core/src/main/resources/org/mybatis/generator/internal/util/messages/messages.properties
+++ b/core/mybatis-generator-core/src/main/resources/org/mybatis/generator/internal/util/messages/messages.properties
@@ -96,7 +96,8 @@ Warning.24=Plugin {0} in context {1} is invalid and will be ignored.
 Warning.25=Table Configuration {0} matched more than one table ({1})
 Warning.26=Column "{0}", in table "{1}", resolves to a property name that is a Java reserved word.  Please specify a column override;
 Warning.27=Exception retrieving table metadata: {0}
-Warning.28=Property {0} exists in root class {1}, but type cannot be determined because the root class is generic.  MyBatis Generator will assume the type matches. 
+Warning.28=Property {0} exists in root class {1}, but type cannot be determined because the root class is generic.  MyBatis Generator will assume the type matches.
+Warning.29=Shortcut field for SQLColumn "{0}" skipped in class {1} due to name collision 
 
 Progress.0=Connecting to the Database
 Progress.1=Introspecting table {0}

--- a/core/mybatis-generator-core/src/test/resources/scripts/CreateDB.sql
+++ b/core/mybatis-generator-core/src/test/resources/scripts/CreateDB.sql
@@ -1,5 +1,5 @@
 --
---    Copyright 2006-2017 the original author or authors.
+--    Copyright 2006-2018 the original author or authors.
 --
 --    Licensed under the Apache License, Version 2.0 (the "License");
 --    you may not use this file except in compliance with the License.
@@ -25,6 +25,8 @@ drop table BlobsOnly if exists;
 drop view NameView if exists;
 drop table RegexRename if exists;
 drop table mbgtest.AnotherAwfulTable if exists;
+drop table mbgtest.Ids if exists;
+drop table mbgtest.Translations if exists;
 drop table CompoundKey if exists;
 drop schema mbgtest if exists;
 drop table EnumTest if exists;
@@ -198,4 +200,16 @@ create table suffix_rename (
   ADDRESS varchar(30),
   ZIP_CODE char(5),
   primary key(ID)
+);
+
+create table mbgtest.Translations (
+  id integer not null,
+  translation varchar(30),
+  primary key (id)
+);
+
+create table mbgtest.Ids (
+  id integer not null,
+  description varchar(30),
+  primary key (id)
 );

--- a/core/mybatis-generator-core/src/test/resources/scripts/generatorConfig_Dsql.xml
+++ b/core/mybatis-generator-core/src/test/resources/scripts/generatorConfig_Dsql.xml
@@ -28,6 +28,10 @@
         connectionURL="jdbc:hsqldb:mem:aname"
         userId="sa" />
 
+    <javaTypeResolver>
+      <property name="useJSR310Types" value="true"/>
+    </javaTypeResolver>
+
     <javaModelGenerator targetPackage="mbg.test.mb3.generated.dsql.model" targetProject="MAVEN">
       <property name="enableSubPackages" value="true" />
       <property name="trimStrings" value="true" />
@@ -67,6 +71,8 @@
       <columnOverride column="id7$$" delimitedColumnName="true" />
       <columnOverride column="class" property="dbClass" />
     </table>
+    <table schema="mbgtest" tableName="Translations" domainObjectName="Translation"/>
+    <table schema="mbgtest" tableName="Ids" domainObjectName="Id"/>
   </context>
 
   <context id="miscellaneousTests_Annotated" targetRuntime="MyBatis3DynamicSql">
@@ -116,6 +122,54 @@
     <table tableName="GeneratedAlwaysTestNoUpdates" >
       <columnOverride column="ID_PLUS1" isGeneratedAlways="true" />
       <columnOverride column="ID_PLUS2" isGeneratedAlways="true" />
+    </table>
+  </context>
+
+  <context id="dsql-modelonly" targetRuntime="MyBatis3DynamicSql">
+    <plugin type="org.mybatis.generator.plugins.EqualsHashCodePlugin" />
+    
+    <jdbcConnection driverClass="org.hsqldb.jdbcDriver"
+        connectionURL="jdbc:hsqldb:mem:aname"
+        userId="sa" />
+
+    <javaTypeResolver>
+      <property name="useJSR310Types" value="true"/>
+    </javaTypeResolver>
+
+    <javaModelGenerator targetPackage="mbg.test.mb3.generated.dsql.modelonly" targetProject="MAVEN">
+      <property name="enableSubPackages" value="true" />
+      <property name="trimStrings" value="true" />
+    </javaModelGenerator>
+
+    <table tableName="FieldsOnly" />
+    <table tableName="PKOnly">
+      <property name="immutable" value="true"/>
+    </table>
+    <table tableName="PKFields" alias="B" >
+      <property name="selectAllOrderByClause" value="ID1, ID2"/>
+      <columnOverride column="wierd$Field" delimitedColumnName="true"/>
+      <columnOverride column="stringBoolean" javaType="boolean" typeHandler="mbg.test.mb3.common.StringBooleanTypeHandler"/>
+    </table>
+    <table tableName="PKBlobs">
+      <property name="constructorBased" value="true"/>
+    </table>
+    <table tableName="PKFieldsBlobs" />
+    <table tableName="FieldsBlobs" />
+    <table tableName="awful table" alias="A">
+      <generatedKey column="CuStOmEr iD" sqlStatement="JDBC" />
+      <columnOverride column="first name" property="firstFirstName" />
+      <columnOverride column="first_name" property="secondFirstName" />
+      <columnOverride column="firstName" property="thirdFirstName" />
+      <columnOverride column="from" delimitedColumnName="true" >
+        <property name="fredswife" value="wilma"/>
+      </columnOverride>
+      <columnOverride column="active" javaType="boolean" />
+      <columnOverride column="_id1" delimitedColumnName="true" />
+      <columnOverride column="$id2" delimitedColumnName="true" />
+      <columnOverride column="id5_" delimitedColumnName="true" />
+      <columnOverride column="id6$" delimitedColumnName="true" />
+      <columnOverride column="id7$$" delimitedColumnName="true" />
+      <columnOverride column="class" property="dbClass" />
     </table>
   </context>
 </generatorConfiguration>

--- a/core/mybatis-generator-systests-common/src/main/resources/mbg/test/common/scripts/CreateDB.sql
+++ b/core/mybatis-generator-systests-common/src/main/resources/mbg/test/common/scripts/CreateDB.sql
@@ -1,5 +1,5 @@
 --
---    Copyright 2006-2017 the original author or authors.
+--    Copyright 2006-2018 the original author or authors.
 --
 --    Licensed under the Apache License, Version 2.0 (the "License");
 --    you may not use this file except in compliance with the License.
@@ -25,6 +25,8 @@ drop table BlobsOnly if exists;
 drop view NameView if exists;
 drop table RegexRename if exists;
 drop table mbgtest.AnotherAwfulTable if exists;
+drop table mbgtest.Ids if exists;
+drop table mbgtest.Translations if exists;
 drop table CompoundKey if exists;
 drop schema mbgtest if exists;
 drop table EnumTest if exists;
@@ -198,4 +200,16 @@ create table suffix_rename (
   ADDRESS varchar(30),
   ZIP_CODE char(5),
   primary key(ID)
+);
+
+create table mbgtest.Translations (
+  id integer not null,
+  translation varchar(30),
+  primary key (id)
+);
+
+create table mbgtest.Ids (
+  id integer not null,
+  description varchar(30),
+  primary key (id)
 );

--- a/core/mybatis-generator-systests-mybatis3-java8/src/main/resources/generatorConfig.xml
+++ b/core/mybatis-generator-systests-mybatis3-java8/src/main/resources/generatorConfig.xml
@@ -40,7 +40,7 @@
     <javaClientGenerator type="ANNOTATEDMAPPER" targetPackage="mbg.test.mb3.generated.dsql.mapper"  targetProject="MAVEN">
       <property name="enableSubPackages" value="true" />
     </javaClientGenerator>
-    
+
     <table tableName="FieldsOnly" />
     <table tableName="PKOnly">
       <property name="immutable" value="true"/>
@@ -71,6 +71,8 @@
       <columnOverride column="id7$$" delimitedColumnName="true" />
       <columnOverride column="class" property="dbClass" />
     </table>
+    <table schema="mbgtest" tableName="Translations" domainObjectName="Translation"/>
+    <table schema="mbgtest" tableName="Ids" domainObjectName="Id"/>
   </context>
 
   <context id="miscellaneousTests_Annotated" targetRuntime="MyBatis3DynamicSql">

--- a/core/mybatis-generator-systests-mybatis3-java8/src/test/java/mbg/test/mb3/dsql/AbstractTest.java
+++ b/core/mybatis-generator-systests-mybatis3-java8/src/test/java/mbg/test/mb3/dsql/AbstractTest.java
@@ -32,6 +32,8 @@ import mbg.test.mb3.generated.dsql.mapper.PkblobsMapper;
 import mbg.test.mb3.generated.dsql.mapper.PkfieldsMapper;
 import mbg.test.mb3.generated.dsql.mapper.PkfieldsblobsMapper;
 import mbg.test.mb3.generated.dsql.mapper.PkonlyMapper;
+import mbg.test.mb3.generated.dsql.mapper.mbgtest.IdMapper;
+import mbg.test.mb3.generated.dsql.mapper.mbgtest.TranslationMapper;
 
 /**
  * @author Jeff Butler
@@ -58,6 +60,8 @@ public abstract class AbstractTest {
         config.addMapper(PkfieldsblobsMapper.class);
         config.addMapper(PkfieldsMapper.class);
         config.addMapper(PkonlyMapper.class);
+        config.addMapper(TranslationMapper.class);
+        config.addMapper(IdMapper.class);
         sqlSessionFactory = new SqlSessionFactoryBuilder().build(config);
     }
 }

--- a/core/mybatis-generator-systests-mybatis3-java8/src/test/java/mbg/test/mb3/dsql/DynamicSqlTest.java
+++ b/core/mybatis-generator-systests-mybatis3-java8/src/test/java/mbg/test/mb3/dsql/DynamicSqlTest.java
@@ -46,6 +46,8 @@ import mbg.test.mb3.generated.dsql.mapper.PkblobsMapper;
 import mbg.test.mb3.generated.dsql.mapper.PkfieldsMapper;
 import mbg.test.mb3.generated.dsql.mapper.PkfieldsblobsMapper;
 import mbg.test.mb3.generated.dsql.mapper.PkonlyMapper;
+import mbg.test.mb3.generated.dsql.mapper.mbgtest.IdMapper;
+import mbg.test.mb3.generated.dsql.mapper.mbgtest.TranslationMapper;
 import mbg.test.mb3.generated.dsql.model.AwfulTable;
 import mbg.test.mb3.generated.dsql.model.Fieldsblobs;
 import mbg.test.mb3.generated.dsql.model.Fieldsonly;
@@ -53,6 +55,8 @@ import mbg.test.mb3.generated.dsql.model.Pkblobs;
 import mbg.test.mb3.generated.dsql.model.Pkfields;
 import mbg.test.mb3.generated.dsql.model.Pkfieldsblobs;
 import mbg.test.mb3.generated.dsql.model.Pkonly;
+import mbg.test.mb3.generated.dsql.model.mbgtest.Id;
+import mbg.test.mb3.generated.dsql.model.mbgtest.Translation;
 
 /**
  * @author Jeff Butler
@@ -3008,6 +3012,66 @@ public class DynamicSqlTest extends AbstractTest {
             assertEquals(2, rows);
         } finally {
             sqlSession.close();
+        }
+    }
+    
+    @Test
+    public void testTranslationTable() {
+        try(SqlSession sqlSession = sqlSessionFactory.openSession()) {
+            TranslationMapper mapper = sqlSession.getMapper(TranslationMapper.class);
+            
+            Translation t = new Translation();
+            t.setId(1);
+            t.setTranslation("Spanish");
+            mapper.insert(t);
+            
+            t = new Translation();
+            t.setId(2);
+            t.setTranslation("French");
+            mapper.insert(t);
+            
+            Translation returnedRecord = mapper.selectByPrimaryKey(2);
+            
+            assertEquals(t.getId(), returnedRecord.getId());
+            assertEquals(t.getTranslation(), returnedRecord.getTranslation());
+            
+            t.setTranslation("Italian");
+            mapper.updateByPrimaryKey(t);
+            
+            returnedRecord = mapper.selectByPrimaryKey(2);
+            
+            assertEquals(t.getId(), returnedRecord.getId());
+            assertEquals(t.getTranslation(), returnedRecord.getTranslation());
+        }
+    }
+    
+    @Test
+    public void testIdTable() {
+        try(SqlSession sqlSession = sqlSessionFactory.openSession()) {
+            IdMapper mapper = sqlSession.getMapper(IdMapper.class);
+            
+            Id id = new Id();
+            id.setId(1);
+            id.setDescription("Spanish");
+            mapper.insert(id);
+            
+            id = new Id();
+            id.setId(2);
+            id.setDescription("French");
+            mapper.insert(id);
+            
+            Id returnedRecord = mapper.selectByPrimaryKey(2);
+            
+            assertEquals(id.getId(), returnedRecord.getId());
+            assertEquals(id.getDescription(), returnedRecord.getDescription());
+            
+            id.setDescription("Italian");
+            mapper.updateByPrimaryKey(id);
+            
+            returnedRecord = mapper.selectByPrimaryKey(2);
+            
+            assertEquals(id.getId(), returnedRecord.getId());
+            assertEquals(id.getDescription(), returnedRecord.getDescription());
         }
     }
     


### PR DESCRIPTION
If a name collision happens, we will not generate the shortcut field in
the MyBatis Dynamic SQL support class.

This resolves #387