### PR TITLE
Remove Plugin Methods Related to iBatis2

### DIFF
--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/Plugin.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/Plugin.java
@@ -179,8 +179,6 @@ public interface Plugin {
      * 
      * @param interfaze
      *            the generated interface if any, may be null
-     * @param topLevelClass
-     *            the generated implementation class if any, may be null
      * @param introspectedTable
      *            The class containing information about the table as
      *            introspected from the database
@@ -189,8 +187,7 @@ public interface Plugin {
      *         first plugin returning false will disable the calling of further
      *         plugins.
      */
-    boolean clientGenerated(Interface interfaze, TopLevelClass topLevelClass,
-            IntrospectedTable introspectedTable);
+    boolean clientGenerated(Interface interfaze, IntrospectedTable introspectedTable);
 
     /**
      * This method is called when the count method has been generated for the mapper interface.
@@ -298,27 +295,6 @@ public interface Plugin {
     
     /**
      * This method is called when the countByExample method has been generated
-     * in the client implementation class.
-     * 
-     * @param method
-     *            the generated countByExample method
-     * @param topLevelClass
-     *            the partially implemented client implementation class. You can
-     *            add additional imported classes to the implementation class if
-     *            necessary.
-     * @param introspectedTable
-     *            The class containing information about the table as
-     *            introspected from the database
-     * @return true if the method should be generated, false if the generated
-     *         method should be ignored. In the case of multiple plugins, the
-     *         first plugin returning false will disable the calling of further
-     *         plugins.
-     */
-    boolean clientCountByExampleMethodGenerated(Method method,
-            TopLevelClass topLevelClass, IntrospectedTable introspectedTable);
-
-    /**
-     * This method is called when the countByExample method has been generated
      * in the client interface.
      * 
      * @param method
@@ -337,27 +313,6 @@ public interface Plugin {
      */
     boolean clientCountByExampleMethodGenerated(Method method,
             Interface interfaze, IntrospectedTable introspectedTable);
-
-    /**
-     * This method is called when the deleteByExample method has been generated
-     * in the client implementation class.
-     * 
-     * @param method
-     *            the generated deleteByExample method
-     * @param topLevelClass
-     *            the partially implemented client implementation class. You can
-     *            add additional imported classes to the implementation class if
-     *            necessary.
-     * @param introspectedTable
-     *            The class containing information about the table as
-     *            introspected from the database
-     * @return true if the method should be generated, false if the generated
-     *         method should be ignored. In the case of multiple plugins, the
-     *         first plugin returning false will disable the calling of further
-     *         plugins.
-     */
-    boolean clientDeleteByExampleMethodGenerated(Method method,
-            TopLevelClass topLevelClass, IntrospectedTable introspectedTable);
 
     /**
      * This method is called when the deleteByExample method has been generated
@@ -400,27 +355,6 @@ public interface Plugin {
      */
     boolean clientDeleteByPrimaryKeyMethodGenerated(Method method,
             Interface interfaze, IntrospectedTable introspectedTable);
-
-    /**
-     * This method is called when the deleteByPrimaryKey method has been
-     * generated in the client implementation class.
-     * 
-     * @param method
-     *            the generated deleteByPrimaryKey method
-     * @param topLevelClass
-     *            the partially implemented client implementation class. You can
-     *            add additional imported classes to the implementation class if
-     *            necessary.
-     * @param introspectedTable
-     *            The class containing information about the table as
-     *            introspected from the database
-     * @return true if the method should be generated, false if the generated
-     *         method should be ignored. In the case of multiple plugins, the
-     *         first plugin returning false will disable the calling of further
-     *         plugins.
-     */
-    boolean clientDeleteByPrimaryKeyMethodGenerated(Method method,
-            TopLevelClass topLevelClass, IntrospectedTable introspectedTable);
 
     /**
      * This method is called when the insert method has been generated in the
@@ -444,27 +378,6 @@ public interface Plugin {
             IntrospectedTable introspectedTable);
 
     /**
-     * This method is called when the insert method has been generated in the
-     * client implementation class.
-     * 
-     * @param method
-     *            the generated insert method
-     * @param topLevelClass
-     *            the partially implemented client implementation class. You can
-     *            add additional imported classes to the implementation class if
-     *            necessary.
-     * @param introspectedTable
-     *            The class containing information about the table as
-     *            introspected from the database
-     * @return true if the method should be generated, false if the generated
-     *         method should be ignored. In the case of multiple plugins, the
-     *         first plugin returning false will disable the calling of further
-     *         plugins.
-     */
-    boolean clientInsertMethodGenerated(Method method,
-            TopLevelClass topLevelClass, IntrospectedTable introspectedTable);
-
-    /**
      * This method is called when the insert selective method has been generated
      * in the client interface.
      * 
@@ -486,27 +399,6 @@ public interface Plugin {
             Interface interfaze, IntrospectedTable introspectedTable);
 
     /**
-     * This method is called when the insert selective method has been generated
-     * in the client implementation class.
-     * 
-     * @param method
-     *            the generated insert method
-     * @param topLevelClass
-     *            the partially implemented client implementation class. You can
-     *            add additional imported classes to the implementation class if
-     *            necessary.
-     * @param introspectedTable
-     *            The class containing information about the table as
-     *            introspected from the database
-     * @return true if the method should be generated, false if the generated
-     *         method should be ignored. In the case of multiple plugins, the
-     *         first plugin returning false will disable the calling of further
-     *         plugins.
-     */
-    boolean clientInsertSelectiveMethodGenerated(Method method,
-            TopLevelClass topLevelClass, IntrospectedTable introspectedTable);
-
-    /**
      * This method is called when the selectByExampleWithBLOBs method has been
      * generated in the client interface.
      * 
@@ -526,27 +418,6 @@ public interface Plugin {
      */
     boolean clientSelectByExampleWithBLOBsMethodGenerated(Method method,
             Interface interfaze, IntrospectedTable introspectedTable);
-
-    /**
-     * This method is called when the selectByExampleWithBLOBs method has been
-     * generated in the client implementation class.
-     * 
-     * @param method
-     *            the generated selectByExampleWithBLOBs method
-     * @param topLevelClass
-     *            the partially implemented client implementation class. You can
-     *            add additional imported classes to the implementation class if
-     *            necessary.
-     * @param introspectedTable
-     *            The class containing information about the table as
-     *            introspected from the database
-     * @return true if the method should be generated, false if the generated
-     *         method should be ignored. In the case of multiple plugins, the
-     *         first plugin returning false will disable the calling of further
-     *         plugins.
-     */
-    boolean clientSelectByExampleWithBLOBsMethodGenerated(Method method,
-            TopLevelClass topLevelClass, IntrospectedTable introspectedTable);
 
     /**
      * This method is called when the selectByExampleWithoutBLOBs method has
@@ -570,27 +441,6 @@ public interface Plugin {
             Interface interfaze, IntrospectedTable introspectedTable);
 
     /**
-     * This method is called when the selectByExampleWithoutBLOBs method has
-     * been generated in the client implementation class.
-     * 
-     * @param method
-     *            the generated selectByExampleWithoutBLOBs method
-     * @param topLevelClass
-     *            the partially implemented client implementation class. You can
-     *            add additional imported classes to the implementation class if
-     *            necessary.
-     * @param introspectedTable
-     *            The class containing information about the table as
-     *            introspected from the database
-     * @return true if the method should be generated, false if the generated
-     *         method should be ignored. In the case of multiple plugins, the
-     *         first plugin returning false will disable the calling of further
-     *         plugins.
-     */
-    boolean clientSelectByExampleWithoutBLOBsMethodGenerated(Method method,
-            TopLevelClass topLevelClass, IntrospectedTable introspectedTable);
-
-    /**
      * This method is called when the selectByPrimaryKey method has been
      * generated in the client interface.
      * 
@@ -610,27 +460,6 @@ public interface Plugin {
      */
     boolean clientSelectByPrimaryKeyMethodGenerated(Method method,
             Interface interfaze, IntrospectedTable introspectedTable);
-
-    /**
-     * This method is called when the selectByPrimaryKey method has been
-     * generated in the client implementation class.
-     * 
-     * @param method
-     *            the generated selectByPrimaryKey method
-     * @param topLevelClass
-     *            the partially implemented client implementation class. You can
-     *            add additional imported classes to the implementation class if
-     *            necessary.
-     * @param introspectedTable
-     *            The class containing information about the table as
-     *            introspected from the database
-     * @return true if the method should be generated, false if the generated
-     *         method should be ignored. In the case of multiple plugins, the
-     *         first plugin returning false will disable the calling of further
-     *         plugins.
-     */
-    boolean clientSelectByPrimaryKeyMethodGenerated(Method method,
-            TopLevelClass topLevelClass, IntrospectedTable introspectedTable);
 
     /**
      * This method is called when the updateByExampleSelective method has been
@@ -654,27 +483,6 @@ public interface Plugin {
             Interface interfaze, IntrospectedTable introspectedTable);
 
     /**
-     * This method is called when the updateByExampleSelective method has been
-     * generated in the client implementation class.
-     * 
-     * @param method
-     *            the generated updateByExampleSelective method
-     * @param topLevelClass
-     *            the partially implemented client implementation class. You can
-     *            add additional imported classes to the implementation class if
-     *            necessary.
-     * @param introspectedTable
-     *            The class containing information about the table as
-     *            introspected from the database
-     * @return true if the method should be generated, false if the generated
-     *         method should be ignored. In the case of multiple plugins, the
-     *         first plugin returning false will disable the calling of further
-     *         plugins.
-     */
-    boolean clientUpdateByExampleSelectiveMethodGenerated(Method method,
-            TopLevelClass topLevelClass, IntrospectedTable introspectedTable);
-
-    /**
      * This method is called when the updateByExampleWithBLOBs method has been
      * generated in the client interface.
      * 
@@ -696,27 +504,6 @@ public interface Plugin {
             Interface interfaze, IntrospectedTable introspectedTable);
 
     /**
-     * This method is called when the updateByExampleWithBLOBs method has been
-     * generated in the client implementation class.
-     * 
-     * @param method
-     *            the generated updateByExampleWithBLOBs method
-     * @param topLevelClass
-     *            the partially implemented client implementation class. You can
-     *            add additional imported classes to the implementation class if
-     *            necessary.
-     * @param introspectedTable
-     *            The class containing information about the table as
-     *            introspected from the database
-     * @return true if the method should be generated, false if the generated
-     *         method should be ignored. In the case of multiple plugins, the
-     *         first plugin returning false will disable the calling of further
-     *         plugins.
-     */
-    boolean clientUpdateByExampleWithBLOBsMethodGenerated(Method method,
-            TopLevelClass topLevelClass, IntrospectedTable introspectedTable);
-
-    /**
      * This method is called when the updateByExampleWithoutBLOBs method has
      * been generated in the client interface.
      * 
@@ -736,27 +523,6 @@ public interface Plugin {
      */
     boolean clientUpdateByExampleWithoutBLOBsMethodGenerated(Method method,
             Interface interfaze, IntrospectedTable introspectedTable);
-
-    /**
-     * This method is called when the updateByExampleWithoutBLOBs method has
-     * been generated in the client implementation class.
-     * 
-     * @param method
-     *            the generated updateByExampleWithoutBLOBs method
-     * @param topLevelClass
-     *            the partially implemented client implementation class. You can
-     *            add additional imported classes to the implementation class if
-     *            necessary.
-     * @param introspectedTable
-     *            The class containing information about the table as
-     *            introspected from the database
-     * @return true if the method should be generated, false if the generated
-     *         method should be ignored. In the case of multiple plugins, the
-     *         first plugin returning false will disable the calling of further
-     *         plugins.
-     */
-    boolean clientUpdateByExampleWithoutBLOBsMethodGenerated(Method method,
-            TopLevelClass topLevelClass, IntrospectedTable introspectedTable);
 
     /**
      * This method is called when the updateByPrimaryKeySelective method has
@@ -780,27 +546,6 @@ public interface Plugin {
             Interface interfaze, IntrospectedTable introspectedTable);
 
     /**
-     * This method is called when the updateByPrimaryKeySelective method has
-     * been generated in the client implementation class.
-     * 
-     * @param method
-     *            the generated updateByPrimaryKeySelective method
-     * @param topLevelClass
-     *            the partially implemented client implementation class. You can
-     *            add additional imported classes to the implementation class if
-     *            necessary.
-     * @param introspectedTable
-     *            The class containing information about the table as
-     *            introspected from the database
-     * @return true if the method should be generated, false if the generated
-     *         method should be ignored. In the case of multiple plugins, the
-     *         first plugin returning false will disable the calling of further
-     *         plugins.
-     */
-    boolean clientUpdateByPrimaryKeySelectiveMethodGenerated(Method method,
-            TopLevelClass topLevelClass, IntrospectedTable introspectedTable);
-
-    /**
      * This method is called when the updateByPrimaryKeyWithBLOBs method has
      * been generated in the client interface.
      * 
@@ -820,48 +565,6 @@ public interface Plugin {
      */
     boolean clientUpdateByPrimaryKeyWithBLOBsMethodGenerated(Method method,
             Interface interfaze, IntrospectedTable introspectedTable);
-
-    /**
-     * This method is called when the updateByPrimaryKeyWithBLOBs method has
-     * been generated in the client implementation class.
-     * 
-     * @param method
-     *            the generated updateByPrimaryKeyWithBLOBs method
-     * @param topLevelClass
-     *            the partially implemented client implementation class. You can
-     *            add additional imported classes to the implementation class if
-     *            necessary.
-     * @param introspectedTable
-     *            The class containing information about the table as
-     *            introspected from the database
-     * @return true if the method should be generated, false if the generated
-     *         method should be ignored. In the case of multiple plugins, the
-     *         first plugin returning false will disable the calling of further
-     *         plugins.
-     */
-    boolean clientUpdateByPrimaryKeyWithBLOBsMethodGenerated(Method method,
-            TopLevelClass topLevelClass, IntrospectedTable introspectedTable);
-
-    /**
-     * This method is called when the updateByPrimaryKeyWithoutBLOBs method has
-     * been generated in the client implementation class.
-     * 
-     * @param method
-     *            the generated updateByPrimaryKeyWithBLOBs method
-     * @param topLevelClass
-     *            the partially implemented client implementation class. You can
-     *            add additional imported classes to the implementation class if
-     *            necessary.
-     * @param introspectedTable
-     *            The class containing information about the table as
-     *            introspected from the database
-     * @return true if the method should be generated, false if the generated
-     *         method should be ignored. In the case of multiple plugins, the
-     *         first plugin returning false will disable the calling of further
-     *         plugins.
-     */
-    boolean clientUpdateByPrimaryKeyWithoutBLOBsMethodGenerated(Method method,
-            TopLevelClass topLevelClass, IntrospectedTable introspectedTable);
 
     /**
      * This method is called when the updateByPrimaryKeyWithoutBLOBs method has
@@ -906,27 +609,6 @@ public interface Plugin {
     boolean clientSelectAllMethodGenerated(Method method,
             Interface interfaze, IntrospectedTable introspectedTable);
 
-    /**
-     * This method is called when the selectAll method has been
-     * generated in the client implementation class.
-     * 
-     * @param method
-     *            the generated selectAll method
-     * @param topLevelClass
-     *            the partially implemented client implementation class. You can
-     *            add additional imported classes to the implementation class if
-     *            necessary.
-     * @param introspectedTable
-     *            The class containing information about the table as
-     *            introspected from the database
-     * @return true if the method should be generated, false if the generated
-     *         method should be ignored. In the case of multiple plugins, the
-     *         first plugin returning false will disable the calling of further
-     *         plugins.
-     */
-    boolean clientSelectAllMethodGenerated(Method method,
-            TopLevelClass topLevelClass, IntrospectedTable introspectedTable);
-    
     /**
      * This method is called after the field is generated for a specific column
      * in a table.

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/PluginAdapter.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/PluginAdapter.java
@@ -128,32 +128,14 @@ public abstract class PluginAdapter implements Plugin {
     }
 
     @Override
-    public boolean clientCountByExampleMethodGenerated(Method method,
-            TopLevelClass topLevelClass, IntrospectedTable introspectedTable) {
-        return true;
-    }
-
-    @Override
     public boolean clientDeleteByExampleMethodGenerated(Method method,
             Interface interfaze, IntrospectedTable introspectedTable) {
         return true;
     }
 
     @Override
-    public boolean clientDeleteByExampleMethodGenerated(Method method,
-            TopLevelClass topLevelClass, IntrospectedTable introspectedTable) {
-        return true;
-    }
-
-    @Override
     public boolean clientDeleteByPrimaryKeyMethodGenerated(Method method,
             Interface interfaze, IntrospectedTable introspectedTable) {
-        return true;
-    }
-
-    @Override
-    public boolean clientDeleteByPrimaryKeyMethodGenerated(Method method,
-            TopLevelClass topLevelClass, IntrospectedTable introspectedTable) {
         return true;
     }
 
@@ -164,14 +146,7 @@ public abstract class PluginAdapter implements Plugin {
     }
 
     @Override
-    public boolean clientInsertMethodGenerated(Method method,
-            TopLevelClass topLevelClass, IntrospectedTable introspectedTable) {
-        return true;
-    }
-
-    @Override
     public boolean clientGenerated(Interface interfaze,
-            TopLevelClass topLevelClass,
             IntrospectedTable introspectedTable) {
         return true;
     }
@@ -183,20 +158,8 @@ public abstract class PluginAdapter implements Plugin {
     }
 
     @Override
-    public boolean clientSelectByExampleWithBLOBsMethodGenerated(Method method,
-            TopLevelClass topLevelClass, IntrospectedTable introspectedTable) {
-        return true;
-    }
-
-    @Override
     public boolean clientSelectByExampleWithoutBLOBsMethodGenerated(Method method,
             Interface interfaze, IntrospectedTable introspectedTable) {
-        return true;
-    }
-
-    @Override
-    public boolean clientSelectByExampleWithoutBLOBsMethodGenerated(Method method,
-            TopLevelClass topLevelClass, IntrospectedTable introspectedTable) {
         return true;
     }
 
@@ -207,20 +170,8 @@ public abstract class PluginAdapter implements Plugin {
     }
 
     @Override
-    public boolean clientSelectByPrimaryKeyMethodGenerated(Method method,
-            TopLevelClass topLevelClass, IntrospectedTable introspectedTable) {
-        return true;
-    }
-
-    @Override
     public boolean clientUpdateByExampleSelectiveMethodGenerated(Method method,
             Interface interfaze, IntrospectedTable introspectedTable) {
-        return true;
-    }
-
-    @Override
-    public boolean clientUpdateByExampleSelectiveMethodGenerated(Method method,
-            TopLevelClass topLevelClass, IntrospectedTable introspectedTable) {
         return true;
     }
 
@@ -231,20 +182,8 @@ public abstract class PluginAdapter implements Plugin {
     }
 
     @Override
-    public boolean clientUpdateByExampleWithBLOBsMethodGenerated(Method method,
-            TopLevelClass topLevelClass, IntrospectedTable introspectedTable) {
-        return true;
-    }
-
-    @Override
     public boolean clientUpdateByExampleWithoutBLOBsMethodGenerated(Method method,
             Interface interfaze, IntrospectedTable introspectedTable) {
-        return true;
-    }
-
-    @Override
-    public boolean clientUpdateByExampleWithoutBLOBsMethodGenerated(Method method,
-            TopLevelClass topLevelClass, IntrospectedTable introspectedTable) {
         return true;
     }
 
@@ -255,33 +194,14 @@ public abstract class PluginAdapter implements Plugin {
     }
 
     @Override
-    public boolean clientUpdateByPrimaryKeySelectiveMethodGenerated(Method method,
-            TopLevelClass topLevelClass, IntrospectedTable introspectedTable) {
-        return true;
-    }
-
-    @Override
     public boolean clientUpdateByPrimaryKeyWithBLOBsMethodGenerated(Method method,
             Interface interfaze, IntrospectedTable introspectedTable) {
-        return true;
-    }
-
-    @Override
-    public boolean clientUpdateByPrimaryKeyWithBLOBsMethodGenerated(Method method,
-            TopLevelClass topLevelClass, IntrospectedTable introspectedTable) {
         return true;
     }
 
     @Override
     public boolean clientUpdateByPrimaryKeyWithoutBLOBsMethodGenerated(
             Method method, Interface interfaze,
-            IntrospectedTable introspectedTable) {
-        return true;
-    }
-
-    @Override
-    public boolean clientUpdateByPrimaryKeyWithoutBLOBsMethodGenerated(
-            Method method, TopLevelClass topLevelClass,
             IntrospectedTable introspectedTable) {
         return true;
     }
@@ -455,12 +375,6 @@ public abstract class PluginAdapter implements Plugin {
     }
 
     @Override
-    public boolean clientInsertSelectiveMethodGenerated(Method method,
-            TopLevelClass topLevelClass, IntrospectedTable introspectedTable) {
-        return true;
-    }
-
-    @Override
     public void initialized(IntrospectedTable introspectedTable) {
     }
 
@@ -551,12 +465,6 @@ public abstract class PluginAdapter implements Plugin {
     @Override
     public boolean clientSelectAllMethodGenerated(Method method,
             Interface interfaze, IntrospectedTable introspectedTable) {
-        return true;
-    }
-
-    @Override
-    public boolean clientSelectAllMethodGenerated(Method method,
-            TopLevelClass topLevelClass, IntrospectedTable introspectedTable) {
         return true;
     }
 

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/JavaMapperGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/JavaMapperGenerator.java
@@ -102,8 +102,7 @@ public class JavaMapperGenerator extends AbstractJavaClientGenerator {
         addUpdateByPrimaryKeyWithoutBLOBsMethod(interfaze);
 
         List<CompilationUnit> answer = new ArrayList<>();
-        if (context.getPlugins().clientGenerated(interfaze, null,
-                introspectedTable)) {
+        if (context.getPlugins().clientGenerated(interfaze, introspectedTable)) {
             answer.add(interfaze);
         }
 

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/SimpleJavaClientGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/SimpleJavaClientGenerator.java
@@ -84,8 +84,7 @@ public class SimpleJavaClientGenerator extends AbstractJavaClientGenerator {
         addUpdateByPrimaryKeyMethod(interfaze);
 
         List<CompilationUnit> answer = new ArrayList<>();
-        if (context.getPlugins().clientGenerated(interfaze, null,
-                introspectedTable)) {
+        if (context.getPlugins().clientGenerated(interfaze, introspectedTable)) {
             answer.add(interfaze);
         }
 

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/internal/PluginAggregator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/internal/PluginAggregator.java
@@ -561,22 +561,6 @@ public final class PluginAggregator implements Plugin {
     }
 
     @Override
-    public boolean clientCountByExampleMethodGenerated(Method method,
-            TopLevelClass topLevelClass, IntrospectedTable introspectedTable) {
-        boolean rc = true;
-
-        for (Plugin plugin : plugins) {
-            if (!plugin.clientCountByExampleMethodGenerated(method, topLevelClass,
-                    introspectedTable)) {
-                rc = false;
-                break;
-            }
-        }
-
-        return rc;
-    }
-
-    @Override
     public boolean clientDeleteByExampleMethodGenerated(Method method,
             Interface interfaze, IntrospectedTable introspectedTable) {
         boolean rc = true;
@@ -584,22 +568,6 @@ public final class PluginAggregator implements Plugin {
         for (Plugin plugin : plugins) {
             if (!plugin.clientDeleteByExampleMethodGenerated(method, interfaze,
                     introspectedTable)) {
-                rc = false;
-                break;
-            }
-        }
-
-        return rc;
-    }
-
-    @Override
-    public boolean clientDeleteByExampleMethodGenerated(Method method,
-            TopLevelClass topLevelClass, IntrospectedTable introspectedTable) {
-        boolean rc = true;
-
-        for (Plugin plugin : plugins) {
-            if (!plugin.clientDeleteByExampleMethodGenerated(method,
-                    topLevelClass, introspectedTable)) {
                 rc = false;
                 break;
             }
@@ -625,22 +593,6 @@ public final class PluginAggregator implements Plugin {
     }
 
     @Override
-    public boolean clientDeleteByPrimaryKeyMethodGenerated(Method method,
-            TopLevelClass topLevelClass, IntrospectedTable introspectedTable) {
-        boolean rc = true;
-
-        for (Plugin plugin : plugins) {
-            if (!plugin.clientDeleteByPrimaryKeyMethodGenerated(method,
-                    topLevelClass, introspectedTable)) {
-                rc = false;
-                break;
-            }
-        }
-
-        return rc;
-    }
-
-    @Override
     public boolean clientInsertMethodGenerated(Method method, Interface interfaze,
             IntrospectedTable introspectedTable) {
         boolean rc = true;
@@ -657,45 +609,12 @@ public final class PluginAggregator implements Plugin {
     }
 
     @Override
-    public boolean clientInsertMethodGenerated(Method method,
-            TopLevelClass topLevelClass, IntrospectedTable introspectedTable) {
-        boolean rc = true;
-
-        for (Plugin plugin : plugins) {
-            if (!plugin.clientInsertMethodGenerated(method, topLevelClass,
-                    introspectedTable)) {
-                rc = false;
-                break;
-            }
-        }
-
-        return rc;
-    }
-
-    @Override
     public boolean clientGenerated(Interface interfaze,
-            TopLevelClass topLevelClass,
             IntrospectedTable introspectedTable) {
         boolean rc = true;
 
         for (Plugin plugin : plugins) {
-            if (!plugin.clientGenerated(interfaze, topLevelClass, introspectedTable)) {
-                rc = false;
-                break;
-            }
-        }
-
-        return rc;
-    }
-
-    @Override
-    public boolean clientSelectAllMethodGenerated(Method method,
-            TopLevelClass topLevelClass, IntrospectedTable introspectedTable) {
-        boolean rc = true;
-
-        for (Plugin plugin : plugins) {
-            if (!plugin.clientSelectAllMethodGenerated(method,
-                    topLevelClass, introspectedTable)) {
+            if (!plugin.clientGenerated(interfaze, introspectedTable)) {
                 rc = false;
                 break;
             }
@@ -737,22 +656,6 @@ public final class PluginAggregator implements Plugin {
     }
 
     @Override
-    public boolean clientSelectByExampleWithBLOBsMethodGenerated(Method method,
-            TopLevelClass topLevelClass, IntrospectedTable introspectedTable) {
-        boolean rc = true;
-
-        for (Plugin plugin : plugins) {
-            if (!plugin.clientSelectByExampleWithBLOBsMethodGenerated(method,
-                    topLevelClass, introspectedTable)) {
-                rc = false;
-                break;
-            }
-        }
-
-        return rc;
-    }
-
-    @Override
     public boolean clientSelectByExampleWithoutBLOBsMethodGenerated(Method method,
             Interface interfaze, IntrospectedTable introspectedTable) {
         boolean rc = true;
@@ -760,22 +663,6 @@ public final class PluginAggregator implements Plugin {
         for (Plugin plugin : plugins) {
             if (!plugin.clientSelectByExampleWithoutBLOBsMethodGenerated(method,
                     interfaze, introspectedTable)) {
-                rc = false;
-                break;
-            }
-        }
-
-        return rc;
-    }
-
-    @Override
-    public boolean clientSelectByExampleWithoutBLOBsMethodGenerated(Method method,
-            TopLevelClass topLevelClass, IntrospectedTable introspectedTable) {
-        boolean rc = true;
-
-        for (Plugin plugin : plugins) {
-            if (!plugin.clientSelectByExampleWithoutBLOBsMethodGenerated(method,
-                    topLevelClass, introspectedTable)) {
                 rc = false;
                 break;
             }
@@ -801,22 +688,6 @@ public final class PluginAggregator implements Plugin {
     }
 
     @Override
-    public boolean clientSelectByPrimaryKeyMethodGenerated(Method method,
-            TopLevelClass topLevelClass, IntrospectedTable introspectedTable) {
-        boolean rc = true;
-
-        for (Plugin plugin : plugins) {
-            if (!plugin.clientSelectByPrimaryKeyMethodGenerated(method,
-                    topLevelClass, introspectedTable)) {
-                rc = false;
-                break;
-            }
-        }
-
-        return rc;
-    }
-
-    @Override
     public boolean clientUpdateByExampleSelectiveMethodGenerated(Method method,
             Interface interfaze, IntrospectedTable introspectedTable) {
         boolean rc = true;
@@ -824,22 +695,6 @@ public final class PluginAggregator implements Plugin {
         for (Plugin plugin : plugins) {
             if (!plugin.clientUpdateByExampleSelectiveMethodGenerated(method,
                     interfaze, introspectedTable)) {
-                rc = false;
-                break;
-            }
-        }
-
-        return rc;
-    }
-
-    @Override
-    public boolean clientUpdateByExampleSelectiveMethodGenerated(Method method,
-            TopLevelClass topLevelClass, IntrospectedTable introspectedTable) {
-        boolean rc = true;
-
-        for (Plugin plugin : plugins) {
-            if (!plugin.clientUpdateByExampleSelectiveMethodGenerated(method,
-                    topLevelClass, introspectedTable)) {
                 rc = false;
                 break;
             }
@@ -865,22 +720,6 @@ public final class PluginAggregator implements Plugin {
     }
 
     @Override
-    public boolean clientUpdateByExampleWithBLOBsMethodGenerated(Method method,
-            TopLevelClass topLevelClass, IntrospectedTable introspectedTable) {
-        boolean rc = true;
-
-        for (Plugin plugin : plugins) {
-            if (!plugin.clientUpdateByExampleWithBLOBsMethodGenerated(method,
-                    topLevelClass, introspectedTable)) {
-                rc = false;
-                break;
-            }
-        }
-
-        return rc;
-    }
-
-    @Override
     public boolean clientUpdateByExampleWithoutBLOBsMethodGenerated(Method method,
             Interface interfaze, IntrospectedTable introspectedTable) {
         boolean rc = true;
@@ -888,22 +727,6 @@ public final class PluginAggregator implements Plugin {
         for (Plugin plugin : plugins) {
             if (!plugin.clientUpdateByExampleWithoutBLOBsMethodGenerated(method,
                     interfaze, introspectedTable)) {
-                rc = false;
-                break;
-            }
-        }
-
-        return rc;
-    }
-
-    @Override
-    public boolean clientUpdateByExampleWithoutBLOBsMethodGenerated(Method method,
-            TopLevelClass topLevelClass, IntrospectedTable introspectedTable) {
-        boolean rc = true;
-
-        for (Plugin plugin : plugins) {
-            if (!plugin.clientUpdateByExampleWithoutBLOBsMethodGenerated(method,
-                    topLevelClass, introspectedTable)) {
                 rc = false;
                 break;
             }
@@ -929,22 +752,6 @@ public final class PluginAggregator implements Plugin {
     }
 
     @Override
-    public boolean clientUpdateByPrimaryKeySelectiveMethodGenerated(Method method,
-            TopLevelClass topLevelClass, IntrospectedTable introspectedTable) {
-        boolean rc = true;
-
-        for (Plugin plugin : plugins) {
-            if (!plugin.clientUpdateByPrimaryKeySelectiveMethodGenerated(method,
-                    topLevelClass, introspectedTable)) {
-                rc = false;
-                break;
-            }
-        }
-
-        return rc;
-    }
-
-    @Override
     public boolean clientUpdateByPrimaryKeyWithBLOBsMethodGenerated(Method method,
             Interface interfaze, IntrospectedTable introspectedTable) {
         boolean rc = true;
@@ -952,22 +759,6 @@ public final class PluginAggregator implements Plugin {
         for (Plugin plugin : plugins) {
             if (!plugin.clientUpdateByPrimaryKeyWithBLOBsMethodGenerated(method,
                     interfaze, introspectedTable)) {
-                rc = false;
-                break;
-            }
-        }
-
-        return rc;
-    }
-
-    @Override
-    public boolean clientUpdateByPrimaryKeyWithBLOBsMethodGenerated(Method method,
-            TopLevelClass topLevelClass, IntrospectedTable introspectedTable) {
-        boolean rc = true;
-
-        for (Plugin plugin : plugins) {
-            if (!plugin.clientUpdateByPrimaryKeyWithBLOBsMethodGenerated(method,
-                    topLevelClass, introspectedTable)) {
                 rc = false;
                 break;
             }
@@ -985,23 +776,6 @@ public final class PluginAggregator implements Plugin {
         for (Plugin plugin : plugins) {
             if (!plugin.clientUpdateByPrimaryKeyWithoutBLOBsMethodGenerated(
                     method, interfaze, introspectedTable)) {
-                rc = false;
-                break;
-            }
-        }
-
-        return rc;
-    }
-
-    @Override
-    public boolean clientUpdateByPrimaryKeyWithoutBLOBsMethodGenerated(
-            Method method, TopLevelClass topLevelClass,
-            IntrospectedTable introspectedTable) {
-        boolean rc = true;
-
-        for (Plugin plugin : plugins) {
-            if (!plugin.clientUpdateByPrimaryKeyWithoutBLOBsMethodGenerated(
-                    method, topLevelClass, introspectedTable)) {
                 rc = false;
                 break;
             }
@@ -1103,22 +877,6 @@ public final class PluginAggregator implements Plugin {
         for (Plugin plugin : plugins) {
             if (!plugin.clientInsertSelectiveMethodGenerated(method, interfaze,
                     introspectedTable)) {
-                rc = false;
-                break;
-            }
-        }
-
-        return rc;
-    }
-
-    @Override
-    public boolean clientInsertSelectiveMethodGenerated(Method method,
-            TopLevelClass topLevelClass, IntrospectedTable introspectedTable) {
-        boolean rc = true;
-
-        for (Plugin plugin : plugins) {
-            if (!plugin.clientInsertSelectiveMethodGenerated(method,
-                    topLevelClass, introspectedTable)) {
                 rc = false;
                 break;
             }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/plugins/MapperAnnotationPlugin.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/plugins/MapperAnnotationPlugin.java
@@ -22,7 +22,6 @@ import org.mybatis.generator.api.IntrospectedTable.TargetRuntime;
 import org.mybatis.generator.api.PluginAdapter;
 import org.mybatis.generator.api.dom.java.FullyQualifiedJavaType;
 import org.mybatis.generator.api.dom.java.Interface;
-import org.mybatis.generator.api.dom.java.TopLevelClass;
 
 public class MapperAnnotationPlugin extends PluginAdapter {
 
@@ -32,8 +31,7 @@ public class MapperAnnotationPlugin extends PluginAdapter {
     }
 
     @Override
-    public boolean clientGenerated(Interface interfaze, TopLevelClass topLevelClass,
-            IntrospectedTable introspectedTable) {
+    public boolean clientGenerated(Interface interfaze, IntrospectedTable introspectedTable) {
 
         if (introspectedTable.getTargetRuntime() == TargetRuntime.MYBATIS3) {
             // don't need to do this for MYBATIS3_DSQL as that runtime already adds this annotation 

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/DynamicSqlMapperGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/DynamicSqlMapperGenerator.java
@@ -105,7 +105,7 @@ public class DynamicSqlMapperGenerator extends AbstractJavaClientGenerator {
         addUpdateByPrimaryKeySelectiveMethod(interfaze);
         
         List<CompilationUnit> answer = new ArrayList<>();
-        if (context.getPlugins().clientGenerated(interfaze, null, introspectedTable)) {
+        if (context.getPlugins().clientGenerated(interfaze, introspectedTable)) {
             answer.add(interfaze);
             answer.add(supportClass);
         }


### PR DESCRIPTION
We no longer support iBatis2. Several plugin methods were only called by
the iBatis2 runtime and can be removed. One plugin method
(clientGenerated) has a signature change.