### PR TITLE
Java and XML DOM Improvements and External DOM Renderers

### DIFF
--- a/core/mybatis-generator-core/infinitest.filters
+++ b/core/mybatis-generator-core/infinitest.filters
@@ -1,0 +1,2 @@
+# exclude tests with the "slow" tag
+excludeGroups slow

--- a/core/mybatis-generator-core/pom.xml
+++ b/core/mybatis-generator-core/pom.xml
@@ -96,6 +96,65 @@
           </execution>
         </executions>
       </plugin>
+
+      <plugin>
+        <artifactId>kotlin-maven-plugin</artifactId>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <executions>
+          <execution>
+            <id>compile</id>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <sourceDirs>
+                <sourceDir>${project.basedir}/src/main/kotlin</sourceDir>
+              </sourceDirs>
+            </configuration>
+          </execution>
+          <execution>
+            <id>test-compile</id>
+            <goals>
+              <goal>test-compile</goal>
+            </goals>
+            <configuration>
+              <sourceDirs>
+                <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
+              </sourceDirs>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <executions>
+          <!-- Replacing default-compile as it is treated specially by maven -->
+          <execution>
+            <id>default-compile</id>
+            <phase>none</phase>
+          </execution>
+          <!-- Replacing default-testCompile as it is treated specially by maven -->
+          <execution>
+            <id>default-testCompile</id>
+            <phase>none</phase>
+          </execution>
+          <execution>
+            <id>java-compile</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>java-test-compile</id>
+              <phase>test-compile</phase>
+              <goals>
+                <goal>testCompile</goal>
+              </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
   
@@ -158,6 +217,10 @@
     <dependency>
       <groupId>com.github.javaparser</groupId>
       <artifactId>javaparser-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib</artifactId>
     </dependency>
   </dependencies>
 

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/DefaultJavaFormatter.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/DefaultJavaFormatter.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2006-2017 the original author or authors.
+ *    Copyright 2006-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,25 +17,47 @@ package org.mybatis.generator.api.dom;
 
 import org.mybatis.generator.api.JavaFormatter;
 import org.mybatis.generator.api.dom.java.CompilationUnit;
+import org.mybatis.generator.api.dom.java.CompilationUnitVisitor;
+import org.mybatis.generator.api.dom.java.Interface;
+import org.mybatis.generator.api.dom.java.TopLevelClass;
+import org.mybatis.generator.api.dom.java.TopLevelEnumeration;
+import org.mybatis.generator.api.dom.java.render.TopLevelClassRenderer;
+import org.mybatis.generator.api.dom.java.render.TopLevelEnumerationRenderer;
+import org.mybatis.generator.api.dom.java.render.TopLevelInterfaceRenderer;
 import org.mybatis.generator.config.Context;
 
 /**
  * This class is the default formatter for generated Java.  This class will use the
- * built in formatting of the DOM classes directly.
+ * built in DOM renderers.
  * 
  * @author Jeff Butler
  *
  */
-public class DefaultJavaFormatter implements JavaFormatter {
+public class DefaultJavaFormatter implements JavaFormatter, CompilationUnitVisitor<String> {
     protected Context context;
 
     @Override
     public String getFormattedContent(CompilationUnit compilationUnit) {
-        return compilationUnit.getFormattedContent();
+        return compilationUnit.accept(this);
     }
 
     @Override
     public void setContext(Context context) {
         this.context = context;
+    }
+
+    @Override
+    public String visit(TopLevelClass topLevelClass) {
+        return new TopLevelClassRenderer().render(topLevelClass);
+    }
+
+    @Override
+    public String visit(TopLevelEnumeration topLevelEnumeration) {
+        return new TopLevelEnumerationRenderer().render(topLevelEnumeration);
+    }
+
+    @Override
+    public String visit(Interface topLevelInterface) {
+        return new TopLevelInterfaceRenderer().render(topLevelInterface);
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/DefaultXmlFormatter.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/DefaultXmlFormatter.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2006-2017 the original author or authors.
+ *    Copyright 2006-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,11 +17,12 @@ package org.mybatis.generator.api.dom;
 
 import org.mybatis.generator.api.XmlFormatter;
 import org.mybatis.generator.api.dom.xml.Document;
+import org.mybatis.generator.api.dom.xml.render.DocumentRenderer;
 import org.mybatis.generator.config.Context;
 
 /**
  * This class is the default formatter for generated XML.  This class will use the
- * built in formatting of the DOM classes directly.
+ * built in document renderer.
  * 
  * @author Jeff Butler
  *
@@ -31,7 +32,7 @@ public class DefaultXmlFormatter implements XmlFormatter {
 
     @Override
     public String getFormattedContent(Document document) {
-        return document.getFormattedContent();
+        return new DocumentRenderer().render(document);
     }
 
     @Override

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/OutputUtilities.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/OutputUtilities.java
@@ -15,22 +15,7 @@
  */
 package org.mybatis.generator.api.dom;
 
-import java.util.Set;
-import java.util.TreeSet;
-
-import org.mybatis.generator.api.dom.java.FullyQualifiedJavaType;
-
 public class OutputUtilities {
-
-    private static final String lineSeparator;
-
-    static {
-        String ls = System.getProperty("line.separator"); //$NON-NLS-1$
-        if (ls == null) {
-            ls = "\n"; //$NON-NLS-1$
-        }
-        lineSeparator = ls;
-    }
 
     /**
      * Utility class - no instances allowed.
@@ -67,39 +52,5 @@ public class OutputUtilities {
         for (int i = 0; i < indentLevel; i++) {
             sb.append("  "); //$NON-NLS-1$
         }
-    }
-
-    /**
-     * Utility method. Adds a newline character to a StringBuilder.
-     * 
-     * @param sb
-     *            the StringBuilder to be appended to
-     */
-    public static void newLine(StringBuilder sb) {
-        sb.append(lineSeparator);
-    }
-
-    /**
-     * returns a unique set of "import xxx;" Strings for the set of types.
-     *
-     * @param importedTypes
-     *            the imported types
-     * @return the sets the
-     */
-    public static Set<String> calculateImports(
-            Set<FullyQualifiedJavaType> importedTypes) {
-        StringBuilder sb = new StringBuilder();
-        Set<String> importStrings = new TreeSet<>();
-        for (FullyQualifiedJavaType fqjt : importedTypes) {
-            for (String importString : fqjt.getImportList()) {
-                sb.setLength(0);
-                sb.append("import "); //$NON-NLS-1$
-                sb.append(importString);
-                sb.append(';');
-                importStrings.add(sb.toString());
-            }
-        }
-
-        return importStrings;
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/AbstractJavaType.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/AbstractJavaType.java
@@ -1,0 +1,98 @@
+/**
+ *    Copyright 2006-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.generator.api.dom.java;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+public abstract class AbstractJavaType extends JavaElement {
+
+    private FullyQualifiedJavaType type;
+
+    private Set<FullyQualifiedJavaType> superInterfaceTypes = new LinkedHashSet<>();
+
+    private List<InnerClass> innerClasses = new ArrayList<>();
+
+    private List<InnerEnum> innerEnums = new ArrayList<>();
+
+    private List<InnerInterface> innerInterfaces = new ArrayList<>();
+
+    private List<Field> fields = new ArrayList<>();
+
+    private List<Method> methods = new ArrayList<>();
+    
+    public AbstractJavaType(FullyQualifiedJavaType type) {
+        this.type = type;
+    }
+
+    public AbstractJavaType(String type) {
+        this.type = new FullyQualifiedJavaType(type);
+    }
+
+    public List<InnerClass> getInnerClasses() {
+        return innerClasses;
+    }
+
+    public void addInnerClass(InnerClass innerClass) {
+        innerClasses.add(innerClass);
+    }
+
+    public List<InnerEnum> getInnerEnums() {
+        return innerEnums;
+    }
+
+    public void addInnerEnum(InnerEnum innerEnum) {
+        innerEnums.add(innerEnum);
+    }
+
+    public List<InnerInterface> getInnerInterfaces() {
+        return innerInterfaces;
+    }
+
+    public void addInnerInterface(InnerInterface innerInterface) {
+        innerInterfaces.add(innerInterface);
+    }
+
+    public List<Field> getFields() {
+        return fields;
+    }
+
+    public void addField(Field field) {
+        fields.add(field);
+    }
+
+    public List<Method> getMethods() {
+        return methods;
+    }
+
+    public void addMethod(Method method) {
+        methods.add(method);
+    }
+
+    public void addSuperInterface(FullyQualifiedJavaType superInterface) {
+        superInterfaceTypes.add(superInterface);
+    }
+
+    public FullyQualifiedJavaType getType() {
+        return type;
+    }
+
+    public Set<FullyQualifiedJavaType> getSuperInterfaceTypes() {
+        return superInterfaceTypes;
+    }
+}

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/CompilationUnit.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/CompilationUnit.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2006-2017 the original author or authors.
+ *    Copyright 2006-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -26,19 +26,9 @@ import java.util.Set;
  */
 public interface CompilationUnit {
 
-    String getFormattedContent();
-
     Set<FullyQualifiedJavaType> getImportedTypes();
 
     Set<String> getStaticImports();
-
-    FullyQualifiedJavaType getSuperClass();
-
-    boolean isJavaInterface();
-
-    boolean isJavaEnumeration();
-
-    Set<FullyQualifiedJavaType> getSuperInterfaceTypes();
 
     FullyQualifiedJavaType getType();
 
@@ -61,4 +51,6 @@ public interface CompilationUnit {
     void addFileCommentLine(String commentLine);
 
     List<String> getFileCommentLines();
+    
+    <R> R accept(CompilationUnitVisitor<R> visitor);
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/CompilationUnitVisitor.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/CompilationUnitVisitor.java
@@ -1,0 +1,24 @@
+/**
+ *    Copyright 2006-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.generator.api.dom.java;
+
+public interface CompilationUnitVisitor<R> {
+    R visit(TopLevelClass topLevelClass);
+    
+    R visit(TopLevelEnumeration topLevelEnumeration);
+    
+    R visit(Interface topLevelInterface);
+}

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/Field.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/Field.java
@@ -15,7 +15,7 @@
  */
 package org.mybatis.generator.api.dom.java;
 
-import org.mybatis.generator.api.dom.OutputUtilities;
+import java.util.Optional;
 
 public class Field extends JavaElement {
     private FullyQualifiedJavaType type;
@@ -23,9 +23,9 @@ public class Field extends JavaElement {
     private String initializationString;
     private boolean isTransient;
     private boolean isVolatile;
+    private boolean isFinal;
 
     public Field(String name, FullyQualifiedJavaType type) {
-        super();
         this.name = name;
         this.type = type;
     }
@@ -35,6 +35,9 @@ public class Field extends JavaElement {
         this.type = field.type;
         this.name = field.name;
         this.initializationString = field.initializationString;
+        this.isTransient = field.isTransient;
+        this.isVolatile = field.isVolatile;
+        this.isFinal = field.isFinal;
     }
 
     public String getName() {
@@ -53,52 +56,12 @@ public class Field extends JavaElement {
         this.type = type;
     }
 
-    public String getInitializationString() {
-        return initializationString;
+    public Optional<String> getInitializationString() {
+        return Optional.ofNullable(initializationString);
     }
 
     public void setInitializationString(String initializationString) {
         this.initializationString = initializationString;
-    }
-
-    public String getFormattedContent(int indentLevel, CompilationUnit compilationUnit) {
-        StringBuilder sb = new StringBuilder();
-
-        addFormattedJavadoc(sb, indentLevel);
-        addFormattedAnnotations(sb, indentLevel);
-
-        OutputUtilities.javaIndent(sb, indentLevel);
-        sb.append(getVisibility().getValue());
-
-        if (isStatic()) {
-            sb.append("static "); //$NON-NLS-1$
-        }
-
-        if (isFinal()) {
-            sb.append("final "); //$NON-NLS-1$
-        }
-
-        if (isTransient()) {
-            sb.append("transient "); //$NON-NLS-1$
-        }
-
-        if (isVolatile()) {
-            sb.append("volatile "); //$NON-NLS-1$
-        }
-
-        sb.append(JavaDomUtils.calculateTypeName(compilationUnit, type));
-
-        sb.append(' ');
-        sb.append(name);
-
-        if (initializationString != null && initializationString.length() > 0) {
-            sb.append(" = "); //$NON-NLS-1$
-            sb.append(initializationString);
-        }
-
-        sb.append(';');
-
-        return sb.toString();
     }
 
     public boolean isTransient() {
@@ -115,5 +78,13 @@ public class Field extends JavaElement {
 
     public void setVolatile(boolean isVolatile) {
         this.isVolatile = isVolatile;
+    }
+
+    public boolean isFinal() {
+        return isFinal;
+    }
+
+    public void setFinal(boolean isFinal) {
+        this.isFinal = isFinal;
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/InitializationBlock.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/InitializationBlock.java
@@ -18,15 +18,12 @@ package org.mybatis.generator.api.dom.java;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.ListIterator;
-
-import org.mybatis.generator.api.dom.OutputUtilities;
 
 public class InitializationBlock {
 
     private boolean isStatic;
-    private List<String> bodyLines;
-    private List<String> javaDocLines;
+    private List<String> bodyLines = new ArrayList<>();
+    private List<String> javaDocLines = new ArrayList<>();
 
     public InitializationBlock() {
         this(false);
@@ -34,8 +31,6 @@ public class InitializationBlock {
 
     public InitializationBlock(boolean isStatic) {
         this.isStatic = isStatic;
-        bodyLines = new ArrayList<>();
-        javaDocLines = new ArrayList<>();
     }
 
     public boolean isStatic() {
@@ -72,62 +67,5 @@ public class InitializationBlock {
 
     public void addJavaDocLine(String javaDocLine) {
         javaDocLines.add(javaDocLine);
-    }
-
-    public String getFormattedContent(int indentLevel) {
-        StringBuilder sb = new StringBuilder();
-
-        for (String javaDocLine : javaDocLines) {
-            OutputUtilities.javaIndent(sb, indentLevel);
-            sb.append(javaDocLine);
-            OutputUtilities.newLine(sb);
-        }
-
-        OutputUtilities.javaIndent(sb, indentLevel);
-
-        if (isStatic) {
-            sb.append("static "); //$NON-NLS-1$
-        }
-
-        sb.append('{');
-        indentLevel++;
-
-        ListIterator<String> listIter = bodyLines.listIterator();
-        while (listIter.hasNext()) {
-            String line = listIter.next();
-            if (line.startsWith("}")) { //$NON-NLS-1$
-                indentLevel--;
-            }
-
-            OutputUtilities.newLine(sb);
-            OutputUtilities.javaIndent(sb, indentLevel);
-            sb.append(line);
-
-            if ((line.endsWith("{") && !line.startsWith("switch")) //$NON-NLS-1$ //$NON-NLS-2$
-                    || line.endsWith(":")) { //$NON-NLS-1$
-                indentLevel++;
-            }
-
-            if (line.startsWith("break")) { //$NON-NLS-1$
-                // if the next line is '}', then don't outdent
-                if (listIter.hasNext()) {
-                    String nextLine = listIter.next();
-                    if (nextLine.startsWith("}")) { //$NON-NLS-1$
-                        indentLevel++;
-                    }
-
-                    // set back to the previous element
-                    listIter.previous();
-                }
-                indentLevel--;
-            }
-        }
-
-        indentLevel--;
-        OutputUtilities.newLine(sb);
-        OutputUtilities.javaIndent(sb, indentLevel);
-        sb.append('}');
-
-        return sb.toString();
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/InnerClass.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/InnerClass.java
@@ -16,12 +16,8 @@
 package org.mybatis.generator.api.dom.java;
 
 import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
-
-import org.mybatis.generator.api.dom.OutputUtilities;
+import java.util.Optional;
 
 /**
  * This class encapsulates the idea of an inner class - it has methods that make
@@ -29,66 +25,28 @@ import org.mybatis.generator.api.dom.OutputUtilities;
  * 
  * @author Jeff Butler
  */
-public class InnerClass extends JavaElement {
+public class InnerClass extends AbstractJavaType {
 
-    private List<Field> fields;
-
-    private List<InnerClass> innerClasses;
-
-    private List<InnerEnum> innerEnums;
-
-    private List<TypeParameter> typeParameters;
+    private List<TypeParameter> typeParameters = new ArrayList<>();
 
     private FullyQualifiedJavaType superClass;
 
-    private FullyQualifiedJavaType type;
-
-    private Set<FullyQualifiedJavaType> superInterfaceTypes;
-
-    private List<Method> methods;
-
     private boolean isAbstract;
 
-    private List<InitializationBlock> initializationBlocks;
+    private List<InitializationBlock> initializationBlocks = new ArrayList<>();
+    
+    private boolean isFinal;
 
-    /**
-     * Instantiates a new inner class.
-     *
-     * @param type
-     *            the type
-     */
     public InnerClass(FullyQualifiedJavaType type) {
-        super();
-        this.type = type;
-        fields = new ArrayList<>();
-        innerClasses = new ArrayList<>();
-        innerEnums = new ArrayList<>();
-        this.typeParameters = new ArrayList<>();
-        superInterfaceTypes = new HashSet<>();
-        methods = new ArrayList<>();
-        initializationBlocks = new ArrayList<>();
+        super(type);
     }
 
-    /**
-     * Instantiates a new inner class.
-     *
-     * @param typeName
-     *            the type name
-     */
-    public InnerClass(String typeName) {
-        this(new FullyQualifiedJavaType(typeName));
+    public InnerClass(String type) {
+        super(type);
     }
 
-    public List<Field> getFields() {
-        return fields;
-    }
-
-    public void addField(Field field) {
-        fields.add(field);
-    }
-
-    public FullyQualifiedJavaType getSuperClass() {
-        return superClass;
+    public Optional<FullyQualifiedJavaType> getSuperClass() {
+        return Optional.ofNullable(superClass);
     }
 
     public void setSuperClass(FullyQualifiedJavaType superClass) {
@@ -97,22 +55,6 @@ public class InnerClass extends JavaElement {
 
     public void setSuperClass(String superClassType) {
         this.superClass = new FullyQualifiedJavaType(superClassType);
-    }
-
-    public List<InnerClass> getInnerClasses() {
-        return innerClasses;
-    }
-
-    public void addInnerClass(InnerClass innerClass) {
-        innerClasses.add(innerClass);
-    }
-
-    public List<InnerEnum> getInnerEnums() {
-        return innerEnums;
-    }
-
-    public void addInnerEnum(InnerEnum innerEnum) {
-        innerEnums.add(innerEnum);
     }
 
     public List<TypeParameter> getTypeParameters() {
@@ -131,164 +73,19 @@ public class InnerClass extends JavaElement {
         initializationBlocks.add(initializationBlock);
     }
 
-    public String getFormattedContent(int indentLevel, CompilationUnit compilationUnit) {
-        StringBuilder sb = new StringBuilder();
-
-        addFormattedJavadoc(sb, indentLevel);
-        addFormattedAnnotations(sb, indentLevel);
-
-        OutputUtilities.javaIndent(sb, indentLevel);
-        sb.append(getVisibility().getValue());
-
-        if (isAbstract()) {
-            sb.append("abstract "); //$NON-NLS-1$
-        }
-
-        if (isStatic()) {
-            sb.append("static "); //$NON-NLS-1$
-        }
-
-        if (isFinal()) {
-            sb.append("final "); //$NON-NLS-1$
-        }
-
-        sb.append("class "); //$NON-NLS-1$
-        sb.append(getType().getShortName());
-
-        if (!this.getTypeParameters().isEmpty()) {
-            boolean comma = false;
-            sb.append("<"); //$NON-NLS-1$
-            for (TypeParameter typeParameter : typeParameters) {
-                if (comma) {
-                    sb.append(", "); //$NON-NLS-1$
-                }
-                sb.append(typeParameter.getFormattedContent(compilationUnit));
-                comma = true;
-            }
-            sb.append("> "); //$NON-NLS-1$
-        }
-
-        if (superClass != null) {
-            sb.append(" extends "); //$NON-NLS-1$
-            sb.append(JavaDomUtils.calculateTypeName(compilationUnit, superClass));
-        }
-
-        if (superInterfaceTypes.size() > 0) {
-            sb.append(" implements "); //$NON-NLS-1$
-
-            boolean comma = false;
-            for (FullyQualifiedJavaType fqjt : superInterfaceTypes) {
-                if (comma) {
-                    sb.append(", "); //$NON-NLS-1$
-                } else {
-                    comma = true;
-                }
-
-                sb.append(JavaDomUtils.calculateTypeName(compilationUnit, fqjt));
-            }
-        }
-
-        sb.append(" {"); //$NON-NLS-1$
-        indentLevel++;
-
-        Iterator<Field> fldIter = fields.iterator();
-        while (fldIter.hasNext()) {
-            OutputUtilities.newLine(sb);
-            Field field = fldIter.next();
-            sb.append(field.getFormattedContent(indentLevel, compilationUnit));
-            if (fldIter.hasNext()) {
-                OutputUtilities.newLine(sb);
-            }
-        }
-
-        if (initializationBlocks.size() > 0) {
-            OutputUtilities.newLine(sb);
-        }
-
-        Iterator<InitializationBlock> blkIter = initializationBlocks.iterator();
-        while (blkIter.hasNext()) {
-            OutputUtilities.newLine(sb);
-            InitializationBlock initializationBlock = blkIter.next();
-            sb.append(initializationBlock.getFormattedContent(indentLevel));
-            if (blkIter.hasNext()) {
-                OutputUtilities.newLine(sb);
-            }
-        }
-
-        if (methods.size() > 0) {
-            OutputUtilities.newLine(sb);
-        }
-
-        Iterator<Method> mtdIter = methods.iterator();
-        while (mtdIter.hasNext()) {
-            OutputUtilities.newLine(sb);
-            Method method = mtdIter.next();
-            sb.append(method.getFormattedContent(indentLevel, false, compilationUnit));
-            if (mtdIter.hasNext()) {
-                OutputUtilities.newLine(sb);
-            }
-        }
-
-        if (innerClasses.size() > 0) {
-            OutputUtilities.newLine(sb);
-        }
-        Iterator<InnerClass> icIter = innerClasses.iterator();
-        while (icIter.hasNext()) {
-            OutputUtilities.newLine(sb);
-            InnerClass innerClass = icIter.next();
-            sb.append(innerClass.getFormattedContent(indentLevel, compilationUnit));
-            if (icIter.hasNext()) {
-                OutputUtilities.newLine(sb);
-            }
-        }
-
-        if (innerEnums.size() > 0) {
-            OutputUtilities.newLine(sb);
-        }
-
-        Iterator<InnerEnum> ieIter = innerEnums.iterator();
-        while (ieIter.hasNext()) {
-            OutputUtilities.newLine(sb);
-            InnerEnum innerEnum = ieIter.next();
-            sb.append(innerEnum.getFormattedContent(indentLevel, compilationUnit));
-            if (ieIter.hasNext()) {
-                OutputUtilities.newLine(sb);
-            }
-        }
-
-        indentLevel--;
-        OutputUtilities.newLine(sb);
-        OutputUtilities.javaIndent(sb, indentLevel);
-        sb.append('}');
-
-        return sb.toString();
-    }
-
-    public Set<FullyQualifiedJavaType> getSuperInterfaceTypes() {
-        return superInterfaceTypes;
-    }
-
-    public void addSuperInterface(FullyQualifiedJavaType superInterface) {
-        superInterfaceTypes.add(superInterface);
-    }
-
-    public List<Method> getMethods() {
-        return methods;
-    }
-
-    public void addMethod(Method method) {
-        methods.add(method);
-    }
-
-    public FullyQualifiedJavaType getType() {
-        return type;
-    }
-
     public boolean isAbstract() {
         return isAbstract;
     }
 
     public void setAbstract(boolean isAbtract) {
         this.isAbstract = isAbtract;
+    }
+
+    public boolean isFinal() {
+        return isFinal;
+    }
+
+    public void setFinal(boolean isFinal) {
+        this.isFinal = isFinal;
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/InnerEnum.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/InnerEnum.java
@@ -16,12 +16,7 @@
 package org.mybatis.generator.api.dom.java;
 
 import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
-
-import org.mybatis.generator.api.dom.OutputUtilities;
 
 /**
  * This class encapsulates the idea of an inner enum - it has methods that make
@@ -29,55 +24,18 @@ import org.mybatis.generator.api.dom.OutputUtilities;
  * 
  * @author Jeff Butler
  */
-public class InnerEnum extends JavaElement {
+public class InnerEnum extends AbstractJavaType {
 
-    private List<Field> fields;
+    private List<String> enumConstants = new ArrayList<>();
 
-    private List<InnerClass> innerClasses;
-
-    private List<InnerEnum> innerEnums;
-
-    private FullyQualifiedJavaType type;
-
-    private Set<FullyQualifiedJavaType> superInterfaceTypes;
-
-    private List<Method> methods;
-
-    private List<String> enumConstants;
-
+    private List<InitializationBlock> initializationBlocks = new ArrayList<>();
+    
     public InnerEnum(FullyQualifiedJavaType type) {
-        super();
-        this.type = type;
-        fields = new ArrayList<>();
-        innerClasses = new ArrayList<>();
-        innerEnums = new ArrayList<>();
-        superInterfaceTypes = new HashSet<>();
-        methods = new ArrayList<>();
-        enumConstants = new ArrayList<>();
+        super(type);
     }
 
-    public List<Field> getFields() {
-        return fields;
-    }
-
-    public void addField(Field field) {
-        fields.add(field);
-    }
-
-    public List<InnerClass> getInnerClasses() {
-        return innerClasses;
-    }
-
-    public void addInnerClass(InnerClass innerClass) {
-        innerClasses.add(innerClass);
-    }
-
-    public List<InnerEnum> getInnerEnums() {
-        return innerEnums;
-    }
-
-    public void addInnerEnum(InnerEnum innerEnum) {
-        innerEnums.add(innerEnum);
+    public InnerEnum(String type) {
+        super(type);
     }
 
     public List<String> getEnumConstants() {
@@ -88,133 +46,11 @@ public class InnerEnum extends JavaElement {
         enumConstants.add(enumConstant);
     }
 
-    public String getFormattedContent(int indentLevel, CompilationUnit compilationUnit) {
-        StringBuilder sb = new StringBuilder();
-
-        addFormattedJavadoc(sb, indentLevel);
-        addFormattedAnnotations(sb, indentLevel);
-
-        OutputUtilities.javaIndent(sb, indentLevel);
-        if (getVisibility() == JavaVisibility.PUBLIC) {
-            sb.append(getVisibility().getValue());
-        }
-
-        sb.append("enum "); //$NON-NLS-1$
-        sb.append(getType().getShortName());
-
-        if (superInterfaceTypes.size() > 0) {
-            sb.append(" implements "); //$NON-NLS-1$
-
-            boolean comma = false;
-            for (FullyQualifiedJavaType fqjt : superInterfaceTypes) {
-                if (comma) {
-                    sb.append(", "); //$NON-NLS-1$
-                } else {
-                    comma = true;
-                }
-
-                sb.append(JavaDomUtils.calculateTypeName(compilationUnit, fqjt));
-            }
-        }
-
-        sb.append(" {"); //$NON-NLS-1$
-        indentLevel++;
-
-        Iterator<String> strIter = enumConstants.iterator();
-        while (strIter.hasNext()) {
-            OutputUtilities.newLine(sb);
-            OutputUtilities.javaIndent(sb, indentLevel);
-            String enumConstant = strIter.next();
-            sb.append(enumConstant);
-
-            if (strIter.hasNext()) {
-                sb.append(',');
-            } else {
-                sb.append(';');
-            }
-        }
-
-        if (fields.size() > 0) {
-            OutputUtilities.newLine(sb);
-        }
-
-        Iterator<Field> fldIter = fields.iterator();
-        while (fldIter.hasNext()) {
-            OutputUtilities.newLine(sb);
-            Field field = fldIter.next();
-            sb.append(field.getFormattedContent(indentLevel, compilationUnit));
-            if (fldIter.hasNext()) {
-                OutputUtilities.newLine(sb);
-            }
-        }
-
-        if (methods.size() > 0) {
-            OutputUtilities.newLine(sb);
-        }
-
-        Iterator<Method> mtdIter = methods.iterator();
-        while (mtdIter.hasNext()) {
-            OutputUtilities.newLine(sb);
-            Method method = mtdIter.next();
-            sb.append(method.getFormattedContent(indentLevel, false, compilationUnit));
-            if (mtdIter.hasNext()) {
-                OutputUtilities.newLine(sb);
-            }
-        }
-
-        if (innerClasses.size() > 0) {
-            OutputUtilities.newLine(sb);
-        }
-
-        Iterator<InnerClass> icIter = innerClasses.iterator();
-        while (icIter.hasNext()) {
-            OutputUtilities.newLine(sb);
-            InnerClass innerClass = icIter.next();
-            sb.append(innerClass.getFormattedContent(indentLevel, compilationUnit));
-            if (icIter.hasNext()) {
-                OutputUtilities.newLine(sb);
-            }
-        }
-
-        if (innerEnums.size() > 0) {
-            OutputUtilities.newLine(sb);
-        }
-
-        Iterator<InnerEnum> ieIter = innerEnums.iterator();
-        while (ieIter.hasNext()) {
-            OutputUtilities.newLine(sb);
-            InnerEnum innerEnum = ieIter.next();
-            sb.append(innerEnum.getFormattedContent(indentLevel, compilationUnit));
-            if (ieIter.hasNext()) {
-                OutputUtilities.newLine(sb);
-            }
-        }
-
-        indentLevel--;
-        OutputUtilities.newLine(sb);
-        OutputUtilities.javaIndent(sb, indentLevel);
-        sb.append('}');
-
-        return sb.toString();
+    public List<InitializationBlock> getInitializationBlocks() {
+        return initializationBlocks;
     }
 
-    public Set<FullyQualifiedJavaType> getSuperInterfaceTypes() {
-        return superInterfaceTypes;
-    }
-
-    public void addSuperInterface(FullyQualifiedJavaType superInterface) {
-        superInterfaceTypes.add(superInterface);
-    }
-
-    public List<Method> getMethods() {
-        return methods;
-    }
-
-    public void addMethod(Method method) {
-        methods.add(method);
-    }
-
-    public FullyQualifiedJavaType getType() {
-        return type;
+    public void addInitializationBlock(InitializationBlock initializationBlock) {
+        initializationBlocks.add(initializationBlock);
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/InnerInterface.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/InnerInterface.java
@@ -15,168 +15,25 @@
  */
 package org.mybatis.generator.api.dom.java;
 
-import static org.mybatis.generator.api.dom.OutputUtilities.javaIndent;
-import static org.mybatis.generator.api.dom.OutputUtilities.newLine;
-
 import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 
-import org.mybatis.generator.api.dom.OutputUtilities;
-
-public class InnerInterface extends JavaElement {
-
-    private List<Field> fields;
-
-    private FullyQualifiedJavaType type;
-
-    private List<InnerInterface> innerInterfaces;
-
-    private Set<FullyQualifiedJavaType> superInterfaceTypes;
-
-    private List<Method> methods;
+public class InnerInterface extends AbstractJavaType {
+    private List<TypeParameter> typeParameters = new ArrayList<>();
 
     public InnerInterface(FullyQualifiedJavaType type) {
-        super();
-        this.type = type;
-        innerInterfaces = new ArrayList<>();
-        superInterfaceTypes = new LinkedHashSet<>();
-        methods = new ArrayList<>();
-        fields = new ArrayList<>();
+        super(type);
     }
 
     public InnerInterface(String type) {
-        this(new FullyQualifiedJavaType(type));
+        super(type);
     }
 
-    public List<Field> getFields() {
-        return fields;
+    public List<TypeParameter> getTypeParameters() {
+        return this.typeParameters;
     }
 
-    public void addField(Field field) {
-        fields.add(field);
-    }
-
-    public String getFormattedContent(int indentLevel, CompilationUnit compilationUnit) {
-        StringBuilder sb = new StringBuilder();
-
-        addFormattedJavadoc(sb, indentLevel);
-        addFormattedAnnotations(sb, indentLevel);
-
-        javaIndent(sb, indentLevel);
-        sb.append(getVisibility().getValue());
-
-        if (isStatic()) {
-            sb.append("static "); //$NON-NLS-1$
-        }
-
-        if (isFinal()) {
-            sb.append("final "); //$NON-NLS-1$
-        }
-
-        sb.append("interface "); //$NON-NLS-1$
-        sb.append(getType().getShortName());
-
-        if (getSuperInterfaceTypes().size() > 0) {
-            sb.append(" extends "); //$NON-NLS-1$
-
-            boolean comma = false;
-            for (FullyQualifiedJavaType fqjt : getSuperInterfaceTypes()) {
-                if (comma) {
-                    sb.append(", "); //$NON-NLS-1$
-                } else {
-                    comma = true;
-                }
-
-                sb.append(JavaDomUtils.calculateTypeName(compilationUnit, fqjt));
-            }
-        }
-
-        sb.append(" {"); //$NON-NLS-1$
-        indentLevel++;
-
-        Iterator<Field> fldIter = fields.iterator();
-        while (fldIter.hasNext()) {
-            OutputUtilities.newLine(sb);
-            Field field = fldIter.next();
-            sb.append(field.getFormattedContent(indentLevel, compilationUnit));
-        }
-
-        if (fields.size() > 0 && methods.size() > 0) {
-            OutputUtilities.newLine(sb);
-        }
-
-        Iterator<Method> mtdIter = getMethods().iterator();
-        while (mtdIter.hasNext()) {
-            newLine(sb);
-            Method method = mtdIter.next();
-            sb.append(method.getFormattedContent(indentLevel, true, compilationUnit));
-            if (mtdIter.hasNext()) {
-                newLine(sb);
-            }
-        }
-
-        if (innerInterfaces.size() > 0) {
-            newLine(sb);
-        }
-        Iterator<InnerInterface> iiIter = innerInterfaces.iterator();
-        while (iiIter.hasNext()) {
-            newLine(sb);
-            InnerInterface innerInterface = iiIter.next();
-            sb.append(innerInterface.getFormattedContent(indentLevel, compilationUnit));
-            if (iiIter.hasNext()) {
-                newLine(sb);
-            }
-        }
-
-        indentLevel--;
-        newLine(sb);
-        javaIndent(sb, indentLevel);
-        sb.append('}');
-
-        return sb.toString();
-    }
-
-    public void addSuperInterface(FullyQualifiedJavaType superInterface) {
-        superInterfaceTypes.add(superInterface);
-    }
-
-    public List<Method> getMethods() {
-        return methods;
-    }
-
-    public void addMethod(Method method) {
-        methods.add(method);
-    }
-
-    public FullyQualifiedJavaType getType() {
-        return type;
-    }
-
-    public FullyQualifiedJavaType getSuperClass() {
-        // interfaces do not have superclasses
-        return null;
-    }
-
-    public Set<FullyQualifiedJavaType> getSuperInterfaceTypes() {
-        return superInterfaceTypes;
-    }
-
-    public List<InnerInterface> getInnerInterfaces() {
-        return innerInterfaces;
-    }
-
-    public void addInnerInterfaces(InnerInterface innerInterface) {
-        innerInterfaces.add(innerInterface);
-    }
-
-    public boolean isJavaInterface() {
-        return true;
-    }
-
-    public boolean isJavaEnumeration() {
-        return false;
+    public void addTypeParameter(TypeParameter typeParameter) {
+        this.typeParameters.add(typeParameter);
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/Interface.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/Interface.java
@@ -15,10 +15,6 @@
  */
 package org.mybatis.generator.api.dom.java;
 
-import static org.mybatis.generator.api.dom.OutputUtilities.calculateImports;
-import static org.mybatis.generator.api.dom.OutputUtilities.newLine;
-import static org.mybatis.generator.internal.util.StringUtility.stringHasValue;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -26,17 +22,14 @@ import java.util.TreeSet;
 
 public class Interface extends InnerInterface implements CompilationUnit {
     
-    private Set<FullyQualifiedJavaType> importedTypes;
+    private Set<FullyQualifiedJavaType> importedTypes = new TreeSet<>();
 
-    private Set<String> staticImports;
+    private Set<String> staticImports = new TreeSet<>();
 
-    private List<String> fileCommentLines;
+    private List<String> fileCommentLines = new ArrayList<>();
 
     public Interface(FullyQualifiedJavaType type) {
         super(type);
-        importedTypes = new TreeSet<>();
-        fileCommentLines = new ArrayList<>();
-        staticImports = new TreeSet<>();
     }
 
     public Interface(String type) {
@@ -54,55 +47,6 @@ public class Interface extends InnerInterface implements CompilationUnit {
                 && !importedType.getPackageName().equals(getType().getPackageName())) {
             importedTypes.add(importedType);
         }
-    }
-
-    @Override
-    public String getFormattedContent() {
-
-        return getFormattedContent(0, this);
-    }
-
-    @Override
-    public String getFormattedContent(int indentLevel, CompilationUnit compilationUnit) {
-        StringBuilder sb = new StringBuilder();
-
-        for (String commentLine : fileCommentLines) {
-            sb.append(commentLine);
-            newLine(sb);
-        }
-
-        if (stringHasValue(getType().getPackageName())) {
-            sb.append("package "); //$NON-NLS-1$
-            sb.append(getType().getPackageName());
-            sb.append(';');
-            newLine(sb);
-            newLine(sb);
-        }
-
-        for (String staticImport : staticImports) {
-            sb.append("import static "); //$NON-NLS-1$
-            sb.append(staticImport);
-            sb.append(';');
-            newLine(sb);
-        }
-
-        if (staticImports.size() > 0) {
-            newLine(sb);
-        }
-
-        Set<String> importStrings = calculateImports(importedTypes);
-        for (String importString : importStrings) {
-            sb.append(importString);
-            newLine(sb);
-        }
-
-        if (importStrings.size() > 0) {
-            newLine(sb);
-        }
-
-        sb.append(super.getFormattedContent(0, this));
-
-        return sb.toString();
     }
 
     @Override
@@ -133,5 +77,10 @@ public class Interface extends InnerInterface implements CompilationUnit {
     @Override
     public void addStaticImports(Set<String> staticImports) {
         this.staticImports.addAll(staticImports);
+    }
+
+    @Override
+    public <R> R accept(CompilationUnitVisitor<R> visitor) {
+        return visitor.visit(this);
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/JavaDomUtils.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/JavaDomUtils.java
@@ -15,6 +15,8 @@
  */
 package org.mybatis.generator.api.dom.java;
 
+import java.util.stream.Collectors;
+
 public class JavaDomUtils {
     /**
      * Calculates type names for writing into generated Java.  We try to
@@ -47,22 +49,9 @@ public class JavaDomUtils {
         String baseTypeName = calculateTypeName(compilationUnit,
                 new FullyQualifiedJavaType(fqjt.getFullyQualifiedNameWithoutTypeParameters()));
 
-        StringBuilder sb = new StringBuilder();
-        sb.append(baseTypeName);
-        sb.append('<');
-        boolean comma = false;
-        for (FullyQualifiedJavaType ft : fqjt.getTypeArguments()) {
-            if (comma) {
-                sb.append(", "); //$NON-NLS-1$
-            } else {
-                comma = true;
-            }
-            sb.append(calculateTypeName(compilationUnit, ft));
-        }
-        sb.append('>');
-
-        return sb.toString();
-
+        return fqjt.getTypeArguments().stream()
+                .map(t -> calculateTypeName(compilationUnit, t))
+                .collect(Collectors.joining(", ", baseTypeName + "<", ">")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
     }
 
     private static boolean typeDoesNotRequireImport(FullyQualifiedJavaType fullyQualifiedJavaType) {

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/JavaElement.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/JavaElement.java
@@ -18,30 +18,22 @@ package org.mybatis.generator.api.dom.java;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.mybatis.generator.api.dom.OutputUtilities;
-
 public abstract class JavaElement {
 
-    private List<String> javaDocLines;
+    private List<String> javaDocLines = new ArrayList<>();
 
     private JavaVisibility visibility = JavaVisibility.DEFAULT;
 
     private boolean isStatic;
 
-    private boolean isFinal;
-
-    private List<String> annotations;
+    private List<String> annotations = new ArrayList<>();
 
     public JavaElement() {
         super();
-        javaDocLines = new ArrayList<>();
-        annotations = new ArrayList<>();
     }
 
     public JavaElement(JavaElement original) {
-        this();
         this.annotations.addAll(original.annotations);
-        this.isFinal = original.isFinal;
         this.isStatic = original.isStatic;
         this.javaDocLines.addAll(original.javaDocLines);
         this.visibility = original.visibility;
@@ -73,30 +65,6 @@ public abstract class JavaElement {
 
     public void addSuppressTypeWarningsAnnotation() {
         addAnnotation("@SuppressWarnings(\"unchecked\")"); //$NON-NLS-1$
-    }
-
-    public void addFormattedJavadoc(StringBuilder sb, int indentLevel) {
-        for (String javaDocLine : javaDocLines) {
-            OutputUtilities.javaIndent(sb, indentLevel);
-            sb.append(javaDocLine);
-            OutputUtilities.newLine(sb);
-        }
-    }
-
-    public void addFormattedAnnotations(StringBuilder sb, int indentLevel) {
-        for (String annotation : annotations) {
-            OutputUtilities.javaIndent(sb, indentLevel);
-            sb.append(annotation);
-            OutputUtilities.newLine(sb);
-        }
-    }
-
-    public boolean isFinal() {
-        return isFinal;
-    }
-
-    public void setFinal(boolean isFinal) {
-        this.isFinal = isFinal;
     }
 
     public boolean isStatic() {

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/Parameter.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/Parameter.java
@@ -18,19 +18,19 @@ package org.mybatis.generator.api.dom.java;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.mybatis.generator.api.dom.java.render.ParameterRenderer;
+
 public class Parameter {
     private String name;
     private FullyQualifiedJavaType type;
     private boolean isVarargs;
 
-    private List<String> annotations;
+    private List<String> annotations = new ArrayList<>();
 
     public Parameter(FullyQualifiedJavaType type, String name, boolean isVarargs) {
-        super();
         this.name = name;
         this.type = type;
         this.isVarargs = isVarargs;
-        annotations = new ArrayList<>();
     }
 
     public Parameter(FullyQualifiedJavaType type, String name) {
@@ -63,28 +63,9 @@ public class Parameter {
         annotations.add(annotation);
     }
 
-    public String getFormattedContent(CompilationUnit compilationUnit) {
-        StringBuilder sb = new StringBuilder();
-
-        for (String annotation : annotations) {
-            sb.append(annotation);
-            sb.append(' ');
-        }
-
-        sb.append(JavaDomUtils.calculateTypeName(compilationUnit, type));
-
-        sb.append(' ');
-        if (isVarargs) {
-            sb.append("... "); //$NON-NLS-1$
-        }
-        sb.append(name);
-
-        return sb.toString();
-    }
-
     @Override
     public String toString() {
-        return getFormattedContent(null);
+        return new ParameterRenderer().render(this, null);
     }
 
     public boolean isVarargs() {

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/TopLevelClass.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/TopLevelClass.java
@@ -15,10 +15,6 @@
  */
 package org.mybatis.generator.api.dom.java;
 
-import static org.mybatis.generator.api.dom.OutputUtilities.calculateImports;
-import static org.mybatis.generator.api.dom.OutputUtilities.newLine;
-import static org.mybatis.generator.internal.util.StringUtility.stringHasValue;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -26,17 +22,14 @@ import java.util.TreeSet;
 
 public class TopLevelClass extends InnerClass implements CompilationUnit {
 
-    private Set<FullyQualifiedJavaType> importedTypes;
+    private Set<FullyQualifiedJavaType> importedTypes = new TreeSet<>();
 
-    private Set<String> staticImports;
+    private Set<String> staticImports = new TreeSet<>();
 
-    private List<String> fileCommentLines;
+    private List<String> fileCommentLines = new ArrayList<>();
 
     public TopLevelClass(FullyQualifiedJavaType type) {
         super(type);
-        importedTypes = new TreeSet<>();
-        fileCommentLines = new ArrayList<>();
-        staticImports = new TreeSet<>();
     }
 
     public TopLevelClass(String typeName) {
@@ -61,59 +54,6 @@ public class TopLevelClass extends InnerClass implements CompilationUnit {
                 && !importedType.getShortName().equals(getType().getShortName())) {
             importedTypes.add(importedType);
         }
-    }
-
-    @Override
-    public String getFormattedContent() {
-        StringBuilder sb = new StringBuilder();
-
-        for (String fileCommentLine : fileCommentLines) {
-            sb.append(fileCommentLine);
-            newLine(sb);
-        }
-
-        if (stringHasValue(getType().getPackageName())) {
-            sb.append("package "); //$NON-NLS-1$
-            sb.append(getType().getPackageName());
-            sb.append(';');
-            newLine(sb);
-            newLine(sb);
-        }
-
-        for (String staticImport : staticImports) {
-            sb.append("import static "); //$NON-NLS-1$
-            sb.append(staticImport);
-            sb.append(';');
-            newLine(sb);
-        }
-
-        if (staticImports.size() > 0) {
-            newLine(sb);
-        }
-
-        Set<String> importStrings = calculateImports(importedTypes);
-        for (String importString : importStrings) {
-            sb.append(importString);
-            newLine(sb);
-        }
-
-        if (importStrings.size() > 0) {
-            newLine(sb);
-        }
-
-        sb.append(super.getFormattedContent(0, this));
-
-        return sb.toString();
-    }
-
-    @Override
-    public boolean isJavaInterface() {
-        return false;
-    }
-
-    @Override
-    public boolean isJavaEnumeration() {
-        return false;
     }
 
     @Override
@@ -144,5 +84,10 @@ public class TopLevelClass extends InnerClass implements CompilationUnit {
     @Override
     public void addStaticImports(Set<String> staticImports) {
         this.staticImports.addAll(staticImports);
+    }
+
+    @Override
+    public <R> R accept(CompilationUnitVisitor<R> visitor) {
+        return visitor.visit(this);
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/TopLevelEnumeration.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/TopLevelEnumeration.java
@@ -15,10 +15,6 @@
  */
 package org.mybatis.generator.api.dom.java;
 
-import static org.mybatis.generator.api.dom.OutputUtilities.calculateImports;
-import static org.mybatis.generator.api.dom.OutputUtilities.newLine;
-import static org.mybatis.generator.internal.util.messages.Messages.getString;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -26,81 +22,23 @@ import java.util.TreeSet;
 
 public class TopLevelEnumeration extends InnerEnum implements CompilationUnit {
 
-    private Set<FullyQualifiedJavaType> importedTypes;
+    private Set<FullyQualifiedJavaType> importedTypes = new TreeSet<>();
 
-    private Set<String> staticImports;
+    private Set<String> staticImports = new TreeSet<>();
 
-    private List<String> fileCommentLines;
+    private List<String> fileCommentLines = new ArrayList<>();
 
     public TopLevelEnumeration(FullyQualifiedJavaType type) {
         super(type);
-        importedTypes = new TreeSet<>();
-        fileCommentLines = new ArrayList<>();
-        staticImports = new TreeSet<>();
     }
 
-    @Override
-    public String getFormattedContent() {
-        StringBuilder sb = new StringBuilder();
-
-        for (String fileCommentLine : fileCommentLines) {
-            sb.append(fileCommentLine);
-            newLine(sb);
-        }
-
-        if (getType().getPackageName() != null
-                && getType().getPackageName().length() > 0) {
-            sb.append("package "); //$NON-NLS-1$
-            sb.append(getType().getPackageName());
-            sb.append(';');
-            newLine(sb);
-            newLine(sb);
-        }
-
-        for (String staticImport : staticImports) {
-            sb.append("import static "); //$NON-NLS-1$
-            sb.append(staticImport);
-            sb.append(';');
-            newLine(sb);
-        }
-
-        if (staticImports.size() > 0) {
-            newLine(sb);
-        }
-
-        Set<String> importStrings = calculateImports(importedTypes);
-        for (String importString : importStrings) {
-            sb.append(importString);
-            newLine(sb);
-        }
-
-        if (importStrings.size() > 0) {
-            newLine(sb);
-        }
-
-        sb.append(super.getFormattedContent(0, this));
-
-        return sb.toString();
+    public TopLevelEnumeration(String type) {
+        super(type);
     }
 
     @Override
     public Set<FullyQualifiedJavaType> getImportedTypes() {
         return importedTypes;
-    }
-
-    @Override
-    public FullyQualifiedJavaType getSuperClass() {
-        throw new UnsupportedOperationException(getString("RuntimeError.11")); //$NON-NLS-1$
-    }
-
-    @Override
-    public boolean isJavaInterface() {
-        return false;
-    }
-
-    @Override
-    public boolean isJavaEnumeration() {
-        return true;
     }
 
     @Override
@@ -140,5 +78,10 @@ public class TopLevelEnumeration extends InnerEnum implements CompilationUnit {
     @Override
     public void addStaticImports(Set<String> staticImports) {
         this.staticImports.addAll(staticImports);
+    }
+
+    @Override
+    public <R> R accept(CompilationUnitVisitor<R> visitor) {
+        return visitor.visit(this);
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/TypeParameter.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/TypeParameter.java
@@ -18,20 +18,23 @@ package org.mybatis.generator.api.dom.java;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.mybatis.generator.api.dom.java.render.TypeParameterRenderer;
+
 public class TypeParameter {
 
     private String name;
 
-    private List<FullyQualifiedJavaType> extendsTypes;
+    private List<FullyQualifiedJavaType> extendsTypes = new ArrayList<>();
 
     public TypeParameter(String name) {
-        this(name, new ArrayList<FullyQualifiedJavaType>());
+        super();
+        this.name = name;
     }
 
     public TypeParameter(String name, List<FullyQualifiedJavaType> extendsTypes) {
         super();
         this.name = name;
-        this.extendsTypes = extendsTypes;
+        this.extendsTypes.addAll(extendsTypes);
     }
 
     public String getName() {
@@ -42,29 +45,8 @@ public class TypeParameter {
         return extendsTypes;
     }
 
-    public String getFormattedContent(CompilationUnit compilationUnit) {
-        StringBuilder sb = new StringBuilder();
-
-        sb.append(name);
-        if (!extendsTypes.isEmpty()) {
-
-            sb.append(" extends "); //$NON-NLS-1$
-            boolean addAnd = false;
-            for (FullyQualifiedJavaType type : extendsTypes) {
-                if (addAnd) {
-                    sb.append(" & "); //$NON-NLS-1$
-                } else {
-                    addAnd = true;
-                }
-                sb.append(JavaDomUtils.calculateTypeName(compilationUnit, type));
-            }
-        }
-
-        return sb.toString();
-    }
-
     @Override
     public String toString() {
-        return getFormattedContent(null);
+        return new TypeParameterRenderer().render(this, null);
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/render/BodyLineRenderer.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/render/BodyLineRenderer.java
@@ -1,0 +1,65 @@
+/**
+ *    Copyright 2006-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.generator.api.dom.java.render;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ListIterator;
+
+import org.mybatis.generator.api.dom.OutputUtilities;
+
+public class BodyLineRenderer {
+
+    public List<String> render(List<String> bodyLines) {
+        List<String> lines = new ArrayList<>();
+        int indentLevel = 1;
+        StringBuilder sb = new StringBuilder();
+
+        ListIterator<String> listIter = bodyLines.listIterator();
+        while (listIter.hasNext()) {
+            sb.setLength(0);
+            String line = listIter.next();
+            if (line.startsWith("}")) { //$NON-NLS-1$
+                indentLevel--;
+            }
+
+            OutputUtilities.javaIndent(sb, indentLevel);
+            sb.append(line);
+            lines.add(sb.toString());
+
+            if ((line.endsWith("{") && !line.startsWith("switch")) //$NON-NLS-1$ //$NON-NLS-2$
+                    || line.endsWith(":")) { //$NON-NLS-1$
+                indentLevel++;
+            }
+
+            if (line.startsWith("break")) { //$NON-NLS-1$
+                // if the next line is '}', then don't outdent
+                if (listIter.hasNext()) {
+                    String nextLine = listIter.next();
+                    if (nextLine.startsWith("}")) { //$NON-NLS-1$
+                        indentLevel++;
+                    }
+
+                    // set back to the previous element
+                    listIter.previous();
+                }
+                indentLevel--;
+            }
+        }
+
+        return lines;
+    }
+}

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/render/FieldRenderer.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/render/FieldRenderer.java
@@ -1,0 +1,71 @@
+/**
+ *    Copyright 2006-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.generator.api.dom.java.render;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.mybatis.generator.api.dom.java.CompilationUnit;
+import org.mybatis.generator.api.dom.java.Field;
+import org.mybatis.generator.api.dom.java.JavaDomUtils;
+
+public class FieldRenderer {
+
+    public List<String> render(Field field, CompilationUnit compilationUnit) {
+        List<String> lines = new ArrayList<>();
+
+        lines.addAll(field.getJavaDocLines());
+        lines.addAll(field.getAnnotations());
+        lines.add(renderField(field, compilationUnit));
+        
+        return lines;
+    }
+    
+    private String renderField(Field field, CompilationUnit compilationUnit) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(field.getVisibility().getValue());
+
+        if (field.isStatic()) {
+            sb.append("static "); //$NON-NLS-1$
+        }
+
+        if (field.isFinal()) {
+            sb.append("final "); //$NON-NLS-1$
+        }
+
+        if (field.isTransient()) {
+            sb.append("transient "); //$NON-NLS-1$
+        }
+
+        if (field.isVolatile()) {
+            sb.append("volatile "); //$NON-NLS-1$
+        }
+
+        sb.append(JavaDomUtils.calculateTypeName(compilationUnit, field.getType()));
+        sb.append(' ');
+        sb.append(field.getName());
+        sb.append(renderInitializationString(field));
+        sb.append(';');
+
+        return sb.toString();
+    }
+    
+    private String renderInitializationString(Field field) {
+        return field.getInitializationString()
+                .map(is -> " = " + is) //$NON-NLS-1$
+                .orElse(""); //$NON-NLS-1$
+    }
+}

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/render/InitializationBlockRenderer.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/render/InitializationBlockRenderer.java
@@ -1,0 +1,45 @@
+/**
+ *    Copyright 2006-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.generator.api.dom.java.render;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.mybatis.generator.api.dom.java.InitializationBlock;
+
+public class InitializationBlockRenderer {
+
+    private BodyLineRenderer bodyLineRenderer = new BodyLineRenderer();
+    
+    public List<String> render(InitializationBlock initializationBlock) {
+        List<String> lines = new ArrayList<>();
+
+        lines.addAll(initializationBlock.getJavaDocLines());
+        lines.add(renderFirstLine(initializationBlock));
+        lines.addAll(bodyLineRenderer.render(initializationBlock.getBodyLines()));
+        lines.add("}"); //$NON-NLS-1$
+        
+        return lines;
+    }
+    
+    private String renderFirstLine(InitializationBlock initializationBlock) {
+        if (initializationBlock.isStatic()) {
+            return "static {"; //$NON-NLS-1$
+        } else {
+            return "{"; //$NON-NLS-1$
+        }
+    }
+}

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/render/InnerClassRenderer.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/render/InnerClassRenderer.java
@@ -1,0 +1,98 @@
+/**
+ *    Copyright 2006-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.generator.api.dom.java.render;
+
+import static org.mybatis.generator.api.dom.java.render.RenderingUtilities.renderClassOrEnumMethods;
+import static org.mybatis.generator.api.dom.java.render.RenderingUtilities.renderFields;
+import static org.mybatis.generator.api.dom.java.render.RenderingUtilities.renderInitializationBlocks;
+import static org.mybatis.generator.api.dom.java.render.RenderingUtilities.renderInnerClasses;
+import static org.mybatis.generator.api.dom.java.render.RenderingUtilities.renderInnerEnums;
+import static org.mybatis.generator.api.dom.java.render.RenderingUtilities.renderInnerInterfaces;
+import static org.mybatis.generator.api.dom.java.render.RenderingUtilities.renderTypeParameters;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.mybatis.generator.api.dom.java.CompilationUnit;
+import org.mybatis.generator.api.dom.java.InnerClass;
+import org.mybatis.generator.api.dom.java.JavaDomUtils;
+import org.mybatis.generator.internal.util.CustomCollectors;
+
+public class InnerClassRenderer {
+    
+    public List<String> render(InnerClass innerClass, CompilationUnit compilationUnit) {
+        List<String> lines = new ArrayList<>();
+        
+        lines.addAll(innerClass.getJavaDocLines());
+        lines.addAll(innerClass.getAnnotations());
+        lines.add(renderFirstLine(innerClass, compilationUnit));
+        lines.addAll(renderFields(innerClass.getFields(), compilationUnit));
+        lines.addAll(renderInitializationBlocks(innerClass.getInitializationBlocks()));
+        lines.addAll(renderClassOrEnumMethods(innerClass.getMethods(), compilationUnit));
+        lines.addAll(renderInnerClasses(innerClass.getInnerClasses(), compilationUnit));
+        lines.addAll(renderInnerInterfaces(innerClass.getInnerInterfaces(), compilationUnit));
+        lines.addAll(renderInnerEnums(innerClass.getInnerEnums(), compilationUnit));
+
+        // last line might be blank, remove it if so
+        if (lines.get(lines.size() - 1).isEmpty()) {
+            lines = lines.subList(0, lines.size() - 1);
+        }
+
+        lines.add("}"); //$NON-NLS-1$
+
+        return lines;
+    }
+
+    private String renderFirstLine(InnerClass innerClass, CompilationUnit compilationUnit) {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append(innerClass.getVisibility().getValue());
+
+        if (innerClass.isAbstract()) {
+            sb.append("abstract "); //$NON-NLS-1$
+        }
+
+        if (innerClass.isStatic()) {
+            sb.append("static "); //$NON-NLS-1$
+        }
+
+        if (innerClass.isFinal()) {
+            sb.append("final "); //$NON-NLS-1$
+        }
+
+        sb.append("class "); //$NON-NLS-1$
+        sb.append(innerClass.getType().getShortName());
+        sb.append(renderTypeParameters(innerClass.getTypeParameters(), compilationUnit));
+        sb.append(renderSuperClass(innerClass, compilationUnit));
+        sb.append(renderSuperInterfaces(innerClass, compilationUnit));
+        sb.append(" {"); //$NON-NLS-1$
+        
+        return sb.toString();
+    }
+
+    private String renderSuperClass(InnerClass innerClass, CompilationUnit compilationUnit) {
+        return innerClass.getSuperClass()
+                .map(sc -> " extends " + JavaDomUtils.calculateTypeName(compilationUnit, sc)) //$NON-NLS-1$
+                .orElse(""); //$NON-NLS-1$        
+    }
+
+    // should return an empty string if no super interfaces
+    private String renderSuperInterfaces(InnerClass innerClass, CompilationUnit compilationUnit) {
+        return innerClass.getSuperInterfaceTypes().stream()
+                .map(tp -> JavaDomUtils.calculateTypeName(compilationUnit, tp))
+                .collect(CustomCollectors.joining(", ", " implements ", "")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+    }
+}

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/render/InnerEnumRenderer.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/render/InnerEnumRenderer.java
@@ -1,0 +1,102 @@
+/**
+ *    Copyright 2006-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.generator.api.dom.java.render;
+
+import static org.mybatis.generator.api.dom.java.render.RenderingUtilities.JAVA_INDENT;
+import static org.mybatis.generator.api.dom.java.render.RenderingUtilities.renderClassOrEnumMethods;
+import static org.mybatis.generator.api.dom.java.render.RenderingUtilities.renderFields;
+import static org.mybatis.generator.api.dom.java.render.RenderingUtilities.renderInitializationBlocks;
+import static org.mybatis.generator.api.dom.java.render.RenderingUtilities.renderInnerClasses;
+import static org.mybatis.generator.api.dom.java.render.RenderingUtilities.renderInnerEnums;
+import static org.mybatis.generator.api.dom.java.render.RenderingUtilities.renderInnerInterfaces;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.mybatis.generator.api.dom.java.CompilationUnit;
+import org.mybatis.generator.api.dom.java.InnerEnum;
+import org.mybatis.generator.api.dom.java.JavaDomUtils;
+import org.mybatis.generator.internal.util.CustomCollectors;
+
+public class InnerEnumRenderer {
+    
+    public List<String> render(InnerEnum innerEnum, CompilationUnit compilationUnit) {
+        List<String> lines = new ArrayList<>();
+        
+        lines.addAll(innerEnum.getJavaDocLines());
+        lines.addAll(innerEnum.getAnnotations());
+        lines.add(renderFirstLine(innerEnum, compilationUnit));
+        lines.addAll(renderEnumConstants(innerEnum));
+        lines.addAll(renderFields(innerEnum.getFields(), compilationUnit));
+        lines.addAll(renderInitializationBlocks(innerEnum.getInitializationBlocks()));
+        lines.addAll(renderClassOrEnumMethods(innerEnum.getMethods(), compilationUnit));
+        lines.addAll(renderInnerClasses(innerEnum.getInnerClasses(), compilationUnit));
+        lines.addAll(renderInnerInterfaces(innerEnum.getInnerInterfaces(), compilationUnit));
+        lines.addAll(renderInnerEnums(innerEnum.getInnerEnums(), compilationUnit));
+
+        // last line might be blank, remove it if so
+        if (lines.get(lines.size() - 1).isEmpty()) {
+            lines = lines.subList(0, lines.size() - 1);
+        }
+
+        lines.add("}"); //$NON-NLS-1$
+
+        return lines;
+    }
+
+    private String renderFirstLine(InnerEnum innerEnum, CompilationUnit compilationUnit) {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append(innerEnum.getVisibility().getValue());
+
+        if (innerEnum.isStatic()) {
+            sb.append("static "); //$NON-NLS-1$
+        }
+
+        sb.append("enum "); //$NON-NLS-1$
+        sb.append(innerEnum.getType().getShortName());
+        sb.append(renderSuperInterfaces(innerEnum, compilationUnit));
+        sb.append(" {"); //$NON-NLS-1$
+        
+        return sb.toString();
+    }
+    
+    private List<String> renderEnumConstants(InnerEnum innerEnum) {
+        List<String> answer = new ArrayList<>();
+        
+        Iterator<String> iter = innerEnum.getEnumConstants().iterator();
+        while (iter.hasNext()) {
+            String enumConstant = iter.next();
+
+            if (iter.hasNext()) {
+                answer.add(JAVA_INDENT + enumConstant + ","); //$NON-NLS-1$
+            } else {
+                answer.add(JAVA_INDENT + enumConstant + ";"); //$NON-NLS-1$
+            }
+        }
+        
+        answer.add(""); //$NON-NLS-1$
+        return answer;
+    }
+
+    // should return an empty string if no super interfaces
+    private String renderSuperInterfaces(InnerEnum innerEnum, CompilationUnit compilationUnit) {
+        return innerEnum.getSuperInterfaceTypes().stream()
+                .map(tp -> JavaDomUtils.calculateTypeName(compilationUnit, tp))
+                .collect(CustomCollectors.joining(", ", " implements ", "")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+    }
+}

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/render/InnerInterfaceRenderer.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/render/InnerInterfaceRenderer.java
@@ -1,0 +1,81 @@
+/**
+ *    Copyright 2006-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.generator.api.dom.java.render;
+
+import static org.mybatis.generator.api.dom.java.render.RenderingUtilities.renderFields;
+import static org.mybatis.generator.api.dom.java.render.RenderingUtilities.renderInnerClasses;
+import static org.mybatis.generator.api.dom.java.render.RenderingUtilities.renderInnerEnums;
+import static org.mybatis.generator.api.dom.java.render.RenderingUtilities.renderInnerInterfaces;
+import static org.mybatis.generator.api.dom.java.render.RenderingUtilities.renderInterfaceMethods;
+import static org.mybatis.generator.api.dom.java.render.RenderingUtilities.renderTypeParameters;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.mybatis.generator.api.dom.java.CompilationUnit;
+import org.mybatis.generator.api.dom.java.InnerInterface;
+import org.mybatis.generator.api.dom.java.JavaDomUtils;
+import org.mybatis.generator.internal.util.CustomCollectors;
+
+public class InnerInterfaceRenderer {
+    
+    public List<String> render(InnerInterface innerInterface, CompilationUnit compilationUnit) {
+        List<String> lines = new ArrayList<>();
+        
+        lines.addAll(innerInterface.getJavaDocLines());
+        lines.addAll(innerInterface.getAnnotations());
+        lines.add(renderFirstLine(innerInterface, compilationUnit));
+        lines.addAll(renderFields(innerInterface.getFields(), compilationUnit));
+        lines.addAll(renderInterfaceMethods(innerInterface.getMethods(), compilationUnit));
+        lines.addAll(renderInnerClasses(innerInterface.getInnerClasses(), compilationUnit));
+        lines.addAll(renderInnerInterfaces(innerInterface.getInnerInterfaces(), compilationUnit));
+        lines.addAll(renderInnerEnums(innerInterface.getInnerEnums(), compilationUnit));
+
+        // last line might be blank, remove it if so
+        if (lines.get(lines.size() - 1).isEmpty()) {
+            lines = lines.subList(0, lines.size() - 1);
+        }
+
+        lines.add("}"); //$NON-NLS-1$
+
+        return lines;
+    }
+
+    private String renderFirstLine(InnerInterface innerInterface, CompilationUnit compilationUnit) {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append(innerInterface.getVisibility().getValue());
+
+        if (innerInterface.isStatic()) {
+            sb.append("static "); //$NON-NLS-1$
+        }
+
+        sb.append("interface "); //$NON-NLS-1$
+        sb.append(innerInterface.getType().getShortName());
+        sb.append(renderTypeParameters(innerInterface.getTypeParameters(), compilationUnit));
+        sb.append(renderSuperInterfaces(innerInterface, compilationUnit));
+        sb.append(" {"); //$NON-NLS-1$
+        
+        return sb.toString();
+    }
+
+    // should return an empty string if no super interfaces
+    private String renderSuperInterfaces(InnerInterface innerInterface, CompilationUnit compilationUnit) {
+        return innerInterface.getSuperInterfaceTypes().stream()
+                .map(tp -> JavaDomUtils.calculateTypeName(compilationUnit, tp))
+                .collect(CustomCollectors.joining(", ", " extends ", "")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+    }
+}

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/render/MethodRenderer.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/render/MethodRenderer.java
@@ -1,0 +1,129 @@
+/**
+ *    Copyright 2006-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.generator.api.dom.java.render;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.mybatis.generator.api.dom.java.CompilationUnit;
+import org.mybatis.generator.api.dom.java.JavaDomUtils;
+import org.mybatis.generator.api.dom.java.JavaVisibility;
+import org.mybatis.generator.api.dom.java.Method;
+import org.mybatis.generator.internal.util.CustomCollectors;
+
+public class MethodRenderer {
+    private TypeParameterRenderer typeParameterRenderer = new TypeParameterRenderer();
+    private ParameterRenderer parameterRenderer = new ParameterRenderer();
+    private BodyLineRenderer bodyLineRenderer = new BodyLineRenderer();
+    
+    public List<String> render(Method method, boolean inInterface, CompilationUnit compilationUnit) {
+        List<String> lines = new ArrayList<>();
+
+        lines.addAll(method.getJavaDocLines());
+        lines.addAll(method.getAnnotations());
+        lines.add(getFirstLine(method, inInterface, compilationUnit));
+        
+        if (!method.isAbstract() && !method.isNative()) {
+            lines.addAll(bodyLineRenderer.render(method.getBodyLines()));
+            lines.add("}"); //$NON-NLS-1$
+        }
+
+        return lines;
+    }
+
+    private String getFirstLine(Method method, boolean inInterface, CompilationUnit compilationUnit) {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append(renderVisibility(method, inInterface));
+
+        if (method.isAbstract() && !inInterface) {
+            sb.append("abstract "); //$NON-NLS-1$
+        }
+
+        if (method.isDefault()) {
+            sb.append("default "); //$NON-NLS-1$
+        }
+
+        if (method.isStatic()) {
+            sb.append("static "); //$NON-NLS-1$
+        }
+
+        if (method.isFinal()) {
+            sb.append("final "); //$NON-NLS-1$
+        }
+
+        if (method.isSynchronized()) {
+            sb.append("synchronized "); //$NON-NLS-1$
+        }
+
+        if (method.isNative()) {
+            sb.append("native "); //$NON-NLS-1$
+        }
+
+        sb.append(renderTypeParameters(method, compilationUnit));
+        
+        if (!method.isConstructor()) {
+            sb.append(method.getReturnType()
+                    .map(t -> JavaDomUtils.calculateTypeName(compilationUnit, t))
+                    .orElse("void")); //$NON-NLS-1$
+            
+            sb.append(' ');
+        }
+
+        sb.append(method.getName());
+        
+        sb.append(renderParameters(method, compilationUnit));
+        
+        sb.append(renderExceptions(method, compilationUnit));
+        
+        if (method.isAbstract() || method.isNative()) {
+            sb.append(';');
+        } else {
+            sb.append(" {"); //$NON-NLS-1$
+        }
+        return sb.toString();
+
+    }
+
+    private String renderVisibility(Method method, boolean inInterface) {
+        if (inInterface && method.getVisibility() == JavaVisibility.PUBLIC) {
+            return ""; //$NON-NLS-1$
+        }
+        
+        return method.getVisibility().getValue();
+    }
+    
+    // should return an empty string if no type parameters
+    private String renderTypeParameters(Method method, CompilationUnit compilationUnit) {
+        return method.getTypeParameters().stream()
+                .map(tp -> typeParameterRenderer.render(tp, compilationUnit))
+                .collect(CustomCollectors.joining(", ", "<", "> ")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+    }
+
+    private String renderParameters(Method method, CompilationUnit compilationUnit) {
+        return method.getParameters().stream()
+                .map(p -> parameterRenderer.render(p, compilationUnit))
+                .collect(Collectors.joining(", ", "(", ")")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+    }
+
+    // should return an empty string if no exceptions
+    private String renderExceptions(Method method, CompilationUnit compilationUnit) {
+        return method.getExceptions().stream()
+                .map(jt -> JavaDomUtils.calculateTypeName(compilationUnit, jt))
+                .collect(CustomCollectors.joining(", ", " throws ", "")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+    }
+}

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/render/ParameterRenderer.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/render/ParameterRenderer.java
@@ -1,0 +1,38 @@
+/**
+ *    Copyright 2006-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.generator.api.dom.java.render;
+
+import org.mybatis.generator.api.dom.java.CompilationUnit;
+import org.mybatis.generator.api.dom.java.JavaDomUtils;
+import org.mybatis.generator.api.dom.java.Parameter;
+import org.mybatis.generator.internal.util.CustomCollectors;
+
+public class ParameterRenderer {
+
+    public String render(Parameter parameter, CompilationUnit compilationUnit) {
+        return renderAnnotations(parameter)
+                + JavaDomUtils.calculateTypeName(compilationUnit, parameter.getType())
+                + " " //$NON-NLS-1$
+                + (parameter.isVarargs() ? "... " : "") //$NON-NLS-1$ //$NON-NLS-2$
+                + parameter.getName();
+    }
+    
+    // should return empty string if no annotations
+    private String renderAnnotations(Parameter parameter) {
+        return parameter.getAnnotations().stream()
+                .collect(CustomCollectors.joining(" ", "", " ")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+    }
+}

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/render/RenderingUtilities.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/render/RenderingUtilities.java
@@ -1,0 +1,197 @@
+/**
+ *    Copyright 2006-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.generator.api.dom.java.render;
+
+import static org.mybatis.generator.internal.util.StringUtility.stringHasValue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.mybatis.generator.api.dom.java.CompilationUnit;
+import org.mybatis.generator.api.dom.java.Field;
+import org.mybatis.generator.api.dom.java.FullyQualifiedJavaType;
+import org.mybatis.generator.api.dom.java.InitializationBlock;
+import org.mybatis.generator.api.dom.java.InnerClass;
+import org.mybatis.generator.api.dom.java.InnerEnum;
+import org.mybatis.generator.api.dom.java.InnerInterface;
+import org.mybatis.generator.api.dom.java.Method;
+import org.mybatis.generator.api.dom.java.TypeParameter;
+import org.mybatis.generator.internal.util.CustomCollectors;
+
+public class RenderingUtilities {
+    public static final String JAVA_INDENT = "    "; //$NON-NLS-1$
+    private static TypeParameterRenderer typeParameterRenderer = new TypeParameterRenderer();
+    private static FieldRenderer fieldRenderer = new FieldRenderer();
+    private static InitializationBlockRenderer initializationBlockRenderer = new InitializationBlockRenderer();
+    private static MethodRenderer methodRenderer = new MethodRenderer();
+    private static InnerClassRenderer innerClassRenderer = new InnerClassRenderer();
+    private static InnerInterfaceRenderer innerInterfaceRenderer = new InnerInterfaceRenderer();
+    private static InnerEnumRenderer innerEnumRenderer = new InnerEnumRenderer();
+
+    // should return an empty string if no type parameters
+    public static String renderTypeParameters(List<TypeParameter> typeParameters, CompilationUnit compilationUnit) {
+        return typeParameters.stream()
+                .map(tp -> typeParameterRenderer.render(tp, compilationUnit))
+                .collect(CustomCollectors.joining(", ", "<", "> ")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+    }
+
+    public static List<String> renderFields(List<Field> fields, CompilationUnit compilationUnit) {
+        return fields.stream()
+                .flatMap(f -> renderField(f, compilationUnit))
+                .collect(Collectors.toList());
+    }
+
+    private static Stream<String> renderField(Field field, CompilationUnit compilationUnit) {
+        return addEmptyLine(fieldRenderer.render(field, compilationUnit).stream()
+                .map(RenderingUtilities::javaIndent));
+    }
+
+    public static List<String> renderInitializationBlocks(List<InitializationBlock> initializationBlocks) {
+        return initializationBlocks.stream()
+                .flatMap(RenderingUtilities::renderInitializationBlock)
+                .collect(Collectors.toList());
+    }
+
+    private static Stream<String> renderInitializationBlock(InitializationBlock initializationBlock) {
+        return addEmptyLine(initializationBlockRenderer.render(initializationBlock).stream()
+                .map(RenderingUtilities::javaIndent));
+    }
+    
+    public static List<String> renderClassOrEnumMethods(List<Method> methods, CompilationUnit compilationUnit) {
+        return methods.stream()
+                .flatMap(m -> renderMethod(m, false, compilationUnit))
+                .collect(Collectors.toList());
+    }
+
+    public static List<String> renderInterfaceMethods(List<Method> methods, CompilationUnit compilationUnit) {
+        return methods.stream()
+                .flatMap(m -> renderMethod(m, true, compilationUnit))
+                .collect(Collectors.toList());
+    }
+
+    private static Stream<String> renderMethod(Method method, boolean inInterface, CompilationUnit compilationUnit) {
+        return addEmptyLine(methodRenderer.render(method, inInterface, compilationUnit).stream()
+                .map(RenderingUtilities::javaIndent));
+    }
+    
+    private static Stream<String> addEmptyLine(Stream<String> in) {
+        return Stream.of(in, Stream.of("")) //$NON-NLS-1$
+                .flatMap(Function.identity());
+    }
+
+    public static List<String> renderInnerClasses(List<InnerClass> innerClasses, CompilationUnit compilationUnit) {
+        return innerClasses.stream()
+                .flatMap(ic -> renderInnerClass(ic, compilationUnit))
+                .collect(Collectors.toList());
+    }
+
+    public static List<String> renderInnerClassNoIndent(InnerClass innerClass, CompilationUnit compilationUnit) {
+        return innerClassRenderer.render(innerClass, compilationUnit);
+    }
+    
+    private static Stream<String> renderInnerClass(InnerClass innerClass, CompilationUnit compilationUnit) {
+        return addEmptyLine(innerClassRenderer.render(innerClass, compilationUnit).stream()
+                .map(RenderingUtilities::javaIndent));
+    }
+    
+    public static List<String> renderInnerInterfaces(List<InnerInterface> innerInterfaces, CompilationUnit compilationUnit) {
+        return innerInterfaces.stream()
+                .flatMap(ii -> renderInnerInterface(ii, compilationUnit))
+                .collect(Collectors.toList());
+    }
+
+    public static List<String> renderInnerInterfaceNoIndent(InnerInterface innerInterface, CompilationUnit compilationUnit) {
+        return innerInterfaceRenderer.render(innerInterface, compilationUnit);
+    }
+    
+    private static Stream<String> renderInnerInterface(InnerInterface innerInterface, CompilationUnit compilationUnit) {
+        return addEmptyLine(innerInterfaceRenderer.render(innerInterface, compilationUnit).stream()
+                .map(RenderingUtilities::javaIndent));
+    }
+    
+    public static List<String> renderInnerEnums(List<InnerEnum> innerEnums, CompilationUnit compilationUnit) {
+        return innerEnums.stream()
+                .flatMap(ie -> renderInnerEnum(ie, compilationUnit))
+                .collect(Collectors.toList());
+    }
+
+    public static List<String> renderInnerEnumNoIndent(InnerEnum innerEnum, CompilationUnit compilationUnit) {
+        return innerEnumRenderer.render(innerEnum, compilationUnit);
+    }
+
+    private static Stream<String> renderInnerEnum(InnerEnum innerEnum, CompilationUnit compilationUnit) {
+        return addEmptyLine(innerEnumRenderer.render(innerEnum, compilationUnit).stream()
+                .map(RenderingUtilities::javaIndent));
+    }
+
+    public static List<String> renderPackage(CompilationUnit compilationUnit) {
+        List<String> answer = new ArrayList<>();
+        
+        String pack = compilationUnit.getType().getPackageName();
+        if (stringHasValue(pack)) {
+            answer.add("package " + pack + ";"); //$NON-NLS-1$ //$NON-NLS-2$
+            answer.add(""); //$NON-NLS-1$
+        }
+        return answer;
+    }
+    
+    public static List<String> renderStaticImports(CompilationUnit compilationUnit) {
+        if (compilationUnit.getStaticImports().isEmpty()) {
+            return Collections.emptyList();
+        }
+        
+        return addEmptyLine(compilationUnit.getStaticImports().stream()
+                .map(s -> "import static " + s + ";")) //$NON-NLS-1$ //$NON-NLS-2$
+                .collect(Collectors.toList());
+    }
+
+    public static List<String> renderImports(CompilationUnit compilationUnit) {
+        Set<String> imports = renderImports(compilationUnit.getImportedTypes());
+        
+        if (imports.isEmpty()) {
+            return Collections.emptyList();
+        }
+        
+        return addEmptyLine(imports.stream()).collect(Collectors.toList());
+    }
+    
+    private static Set<String> renderImports(Set<FullyQualifiedJavaType> imports) {
+        return imports.stream()
+                .map(FullyQualifiedJavaType::getImportList)
+                .flatMap(List::stream)
+                .map(RenderingUtilities::toFullImport)
+                .collect(Collectors.toCollection(TreeSet::new));
+    }
+    
+    private static String toFullImport(String s) {
+        return "import " + s + ";"; //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+
+    private static String javaIndent(String in) {
+        if (in.isEmpty()) {
+            return in; // don't indent empty lines
+        }
+        
+        return JAVA_INDENT + in;
+    }
+}

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/render/TopLevelClassRenderer.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/render/TopLevelClassRenderer.java
@@ -1,0 +1,43 @@
+/**
+ *    Copyright 2006-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.generator.api.dom.java.render;
+
+import static org.mybatis.generator.api.dom.java.render.RenderingUtilities.renderImports;
+import static org.mybatis.generator.api.dom.java.render.RenderingUtilities.renderInnerClassNoIndent;
+import static org.mybatis.generator.api.dom.java.render.RenderingUtilities.renderPackage;
+import static org.mybatis.generator.api.dom.java.render.RenderingUtilities.renderStaticImports;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.mybatis.generator.api.dom.java.TopLevelClass;
+
+public class TopLevelClassRenderer {
+
+    public String render(TopLevelClass topLevelClass) {
+        List<String> lines = new ArrayList<>();
+        
+        lines.addAll(topLevelClass.getFileCommentLines());
+        lines.addAll(renderPackage(topLevelClass));
+        lines.addAll(renderStaticImports(topLevelClass));
+        lines.addAll(renderImports(topLevelClass));
+        lines.addAll(renderInnerClassNoIndent(topLevelClass, topLevelClass));
+        
+        return lines.stream()
+                .collect(Collectors.joining(System.getProperty("line.separator"))); //$NON-NLS-1$
+    }    
+}

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/render/TopLevelEnumerationRenderer.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/render/TopLevelEnumerationRenderer.java
@@ -1,0 +1,43 @@
+/**
+ *    Copyright 2006-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.generator.api.dom.java.render;
+
+import static org.mybatis.generator.api.dom.java.render.RenderingUtilities.renderImports;
+import static org.mybatis.generator.api.dom.java.render.RenderingUtilities.renderInnerEnumNoIndent;
+import static org.mybatis.generator.api.dom.java.render.RenderingUtilities.renderPackage;
+import static org.mybatis.generator.api.dom.java.render.RenderingUtilities.renderStaticImports;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.mybatis.generator.api.dom.java.TopLevelEnumeration;
+
+public class TopLevelEnumerationRenderer {
+
+    public String render(TopLevelEnumeration topLevelEnumeration) {
+        List<String> lines = new ArrayList<>();
+        
+        lines.addAll(topLevelEnumeration.getFileCommentLines());
+        lines.addAll(renderPackage(topLevelEnumeration));
+        lines.addAll(renderStaticImports(topLevelEnumeration));
+        lines.addAll(renderImports(topLevelEnumeration));
+        lines.addAll(renderInnerEnumNoIndent(topLevelEnumeration, topLevelEnumeration));
+        
+        return lines.stream()
+                .collect(Collectors.joining(System.getProperty("line.separator"))); //$NON-NLS-1$
+    }    
+}

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/render/TopLevelInterfaceRenderer.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/render/TopLevelInterfaceRenderer.java
@@ -1,0 +1,43 @@
+/**
+ *    Copyright 2006-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.generator.api.dom.java.render;
+
+import static org.mybatis.generator.api.dom.java.render.RenderingUtilities.renderImports;
+import static org.mybatis.generator.api.dom.java.render.RenderingUtilities.renderInnerInterfaceNoIndent;
+import static org.mybatis.generator.api.dom.java.render.RenderingUtilities.renderPackage;
+import static org.mybatis.generator.api.dom.java.render.RenderingUtilities.renderStaticImports;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.mybatis.generator.api.dom.java.Interface;
+
+public class TopLevelInterfaceRenderer {
+
+    public String render(Interface topLevelInterface) {
+        List<String> lines = new ArrayList<>();
+
+        lines.addAll(topLevelInterface.getFileCommentLines());
+        lines.addAll(renderPackage(topLevelInterface));
+        lines.addAll(renderStaticImports(topLevelInterface));
+        lines.addAll(renderImports(topLevelInterface));
+        lines.addAll(renderInnerInterfaceNoIndent(topLevelInterface, topLevelInterface));
+        
+        return lines.stream()
+                .collect(Collectors.joining(System.getProperty("line.separator"))); //$NON-NLS-1$
+    }    
+}

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/render/TypeParameterRenderer.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/render/TypeParameterRenderer.java
@@ -1,0 +1,29 @@
+/**
+ *    Copyright 2006-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.generator.api.dom.java.render;
+
+import org.mybatis.generator.api.dom.java.CompilationUnit;
+import org.mybatis.generator.api.dom.java.JavaDomUtils;
+import org.mybatis.generator.api.dom.java.TypeParameter;
+import org.mybatis.generator.internal.util.CustomCollectors;
+
+public class TypeParameterRenderer {
+    public String render(TypeParameter typeParameter, CompilationUnit compilationUnit) {
+        return typeParameter.getName() + typeParameter.getExtendsTypes().stream()
+                .map(t -> JavaDomUtils.calculateTypeName(compilationUnit, t))
+                .collect(CustomCollectors.joining(" & ", " extends ", "")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+    }
+}

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/xml/Attribute.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/xml/Attribute.java
@@ -35,16 +35,6 @@ public class Attribute implements Comparable<Attribute> {
         return value;
     }
 
-    public String getFormattedContent() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(name);
-        sb.append("=\""); //$NON-NLS-1$
-        sb.append(value);
-        sb.append('\"');
-
-        return sb.toString();
-    }
-
     @Override
     public int compareTo(Attribute o) {
         if (this.name == null) {

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/xml/DocType.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/xml/DocType.java
@@ -1,0 +1,20 @@
+/**
+ *    Copyright 2006-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.generator.api.dom.xml;
+
+public interface DocType {
+    <R> R accept(DocTypeVisitor<R> visitor);
+}

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/xml/DocTypeVisitor.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/xml/DocTypeVisitor.java
@@ -1,0 +1,22 @@
+/**
+ *    Copyright 2006-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.generator.api.dom.xml;
+
+public interface DocTypeVisitor<R> {
+    R visit(PublicDocType docType);
+    
+    R visit(SystemDocType docType);
+}

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/xml/Document.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/xml/Document.java
@@ -15,20 +15,22 @@
  */
 package org.mybatis.generator.api.dom.xml;
 
-import org.mybatis.generator.api.dom.OutputUtilities;
+import java.util.Optional;
 
 public class Document {
 
-    private String publicId;
-
-    private String systemId;
+    private DocType docType;
 
     private XmlElement rootElement;
 
     public Document(String publicId, String systemId) {
         super();
-        this.publicId = publicId;
-        this.systemId = systemId;
+        docType = new PublicDocType(publicId, systemId);
+    }
+
+    public Document(String systemId) {
+        super();
+        docType = new SystemDocType(systemId);
     }
 
     public Document() {
@@ -42,34 +44,8 @@ public class Document {
     public void setRootElement(XmlElement rootElement) {
         this.rootElement = rootElement;
     }
-
-    public String getPublicId() {
-        return publicId;
-    }
-
-    public String getSystemId() {
-        return systemId;
-    }
-
-    public String getFormattedContent() {
-        StringBuilder sb = new StringBuilder();
-
-        sb.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"); //$NON-NLS-1$
-
-        if (publicId != null && systemId != null) {
-            OutputUtilities.newLine(sb);
-            sb.append("<!DOCTYPE "); //$NON-NLS-1$
-            sb.append(rootElement.getName());
-            sb.append(" PUBLIC \""); //$NON-NLS-1$
-            sb.append(publicId);
-            sb.append("\" \""); //$NON-NLS-1$
-            sb.append(systemId);
-            sb.append("\">"); //$NON-NLS-1$
-        }
-
-        OutputUtilities.newLine(sb);
-        sb.append(rootElement.getFormattedContent(0));
-
-        return sb.toString();
+    
+    public Optional<DocType> getDocType() {
+        return Optional.ofNullable(docType);
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/xml/Element.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/xml/Element.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2006-2017 the original author or authors.
+ *    Copyright 2006-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -20,6 +20,6 @@ public abstract class Element {
     public Element() {
         super();
     }
-
-    public abstract String getFormattedContent(int indentLevel);
+    
+    public abstract <R> R accept(ElementVisitor<R> visitor);
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/xml/ElementVisitor.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/xml/ElementVisitor.java
@@ -1,0 +1,22 @@
+/**
+ *    Copyright 2006-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.generator.api.dom.xml;
+
+public interface ElementVisitor<R> {
+    R visit(TextElement element);
+    
+    R visit(XmlElement element);
+}

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/xml/PublicDocType.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/xml/PublicDocType.java
@@ -1,0 +1,40 @@
+/**
+ *    Copyright 2006-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.generator.api.dom.xml;
+
+public class PublicDocType implements DocType {
+    private String dtdLocation;
+    private String dtdName;
+
+    public PublicDocType(String dtdName, String dtdLocation) {
+        super();
+        this.dtdName = dtdName;
+        this.dtdLocation = dtdLocation;
+    }
+
+    public String getDtdLocation() {
+        return dtdLocation;
+    }
+
+    public String getDtdName() {
+        return dtdName;
+    }
+
+    @Override
+    public <R> R accept(DocTypeVisitor<R> visitor) {
+        return visitor.visit(this);
+    }
+}

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/xml/SystemDocType.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/xml/SystemDocType.java
@@ -1,0 +1,34 @@
+/**
+ *    Copyright 2006-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.generator.api.dom.xml;
+
+public class SystemDocType implements DocType {
+    private String dtdLocation;
+
+    public SystemDocType(String dtdLocation) {
+        super();
+        this.dtdLocation = dtdLocation;
+    }
+
+    public String getDtdLocation() {
+        return dtdLocation;
+    }
+
+    @Override
+    public <R> R accept(DocTypeVisitor<R> visitor) {
+        return visitor.visit(this);
+    }
+}

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/xml/TextElement.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/xml/TextElement.java
@@ -15,8 +15,6 @@
  */
 package org.mybatis.generator.api.dom.xml;
 
-import org.mybatis.generator.api.dom.OutputUtilities;
-
 public class TextElement extends Element {
 
     private String content;
@@ -26,15 +24,12 @@ public class TextElement extends Element {
         this.content = content;
     }
 
-    @Override
-    public String getFormattedContent(int indentLevel) {
-        StringBuilder sb = new StringBuilder();
-        OutputUtilities.xmlIndent(sb, indentLevel);
-        sb.append(content);
-        return sb.toString();
-    }
-
     public String getContent() {
         return content;
+    }
+
+    @Override
+    public <R> R accept(ElementVisitor<R> visitor) {
+        return visitor.visit(this);
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/xml/XmlElement.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/xml/XmlElement.java
@@ -16,23 +16,18 @@
 package org.mybatis.generator.api.dom.xml;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-
-import org.mybatis.generator.api.dom.OutputUtilities;
 
 public class XmlElement extends Element {
 
-    private List<Attribute> attributes;
+    private List<Attribute> attributes = new ArrayList<>();
 
-    private List<Element> elements;
+    private List<Element> elements = new ArrayList<>();
 
     private String name;
 
     public XmlElement(String name) {
         super();
-        attributes = new ArrayList<>();
-        elements = new ArrayList<>();
         this.name = name;
     }
 
@@ -44,9 +39,7 @@ public class XmlElement extends Element {
      */
     public XmlElement(XmlElement original) {
         super();
-        attributes = new ArrayList<>();
         attributes.addAll(original.attributes);
-        elements = new ArrayList<>();
         elements.addAll(original.elements);
         this.name = original.name;
     }
@@ -74,41 +67,17 @@ public class XmlElement extends Element {
     public String getName() {
         return name;
     }
-
-    @Override
-    public String getFormattedContent(int indentLevel) {
-        StringBuilder sb = new StringBuilder();
-
-        OutputUtilities.xmlIndent(sb, indentLevel);
-        sb.append('<');
-        sb.append(name);
-
-        Collections.sort(attributes);
-        for (Attribute att : attributes) {
-            sb.append(' ');
-            sb.append(att.getFormattedContent());
-        }
-
-        if (elements.size() > 0) {
-            sb.append(">"); //$NON-NLS-1$
-            for (Element element : elements) {
-                OutputUtilities.newLine(sb);
-                sb.append(element.getFormattedContent(indentLevel + 1));
-            }
-            OutputUtilities.newLine(sb);
-            OutputUtilities.xmlIndent(sb, indentLevel);
-            sb.append("</"); //$NON-NLS-1$
-            sb.append(name);
-            sb.append('>');
-
-        } else {
-            sb.append(" />"); //$NON-NLS-1$
-        }
-
-        return sb.toString();
+    
+    public boolean hasChildren() {
+        return elements.size() > 0;
     }
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    @Override
+    public <R> R accept(ElementVisitor<R> visitor) {
+        return visitor.visit(this);
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/xml/render/AttributeRenderer.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/xml/render/AttributeRenderer.java
@@ -1,0 +1,28 @@
+/**
+ *    Copyright 2006-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.generator.api.dom.xml.render;
+
+import org.mybatis.generator.api.dom.xml.Attribute;
+
+public class AttributeRenderer {
+
+    public String render(Attribute attribute) {
+        return attribute.getName()
+                + "=\"" //$NON-NLS-1$
+                + attribute.getValue()
+                + "\""; //$NON-NLS-1$
+    }
+}

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/xml/render/DocTypeRenderer.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/xml/render/DocTypeRenderer.java
@@ -1,0 +1,39 @@
+/**
+ *    Copyright 2006-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.generator.api.dom.xml.render;
+
+import org.mybatis.generator.api.dom.xml.DocTypeVisitor;
+import org.mybatis.generator.api.dom.xml.PublicDocType;
+import org.mybatis.generator.api.dom.xml.SystemDocType;
+
+public class DocTypeRenderer implements DocTypeVisitor<String> {
+
+    @Override
+    public String visit(PublicDocType docType) {
+        return "PUBLIC \"" //$NON-NLS-1$
+                + docType.getDtdName()
+                + "\" \"" //$NON-NLS-1$
+                + docType.getDtdLocation()
+                + "\""; //$NON-NLS-1$
+    }
+
+    @Override
+    public String visit(SystemDocType docType) {
+        return "SYSTEM \"" //$NON-NLS-1$
+                + docType.getDtdLocation()
+                + "\""; //$NON-NLS-1$
+    }
+}

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/xml/render/DocumentRenderer.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/xml/render/DocumentRenderer.java
@@ -1,0 +1,53 @@
+/**
+ *    Copyright 2006-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.generator.api.dom.xml.render;
+
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.mybatis.generator.api.dom.xml.DocType;
+import org.mybatis.generator.api.dom.xml.Document;
+
+public class DocumentRenderer {
+
+    public String render(Document document) {
+        return Stream.of(renderXmlHeader(),
+                renderDocType(document),
+                renderRootElement(document))
+                .flatMap(Function.identity())
+                .collect(Collectors.joining(System.getProperty("line.separator"))); //$NON-NLS-1$
+    }
+
+    private Stream<String> renderXmlHeader() {
+        return Stream.of("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"); //$NON-NLS-1$
+    }
+    
+    private Stream<String> renderDocType(Document document) {
+        return Stream.of("<!DOCTYPE " //$NON-NLS-1$
+                + document.getRootElement().getName()
+                + document.getDocType().map(this::renderDocType).orElse("") //$NON-NLS-1$
+                + ">"); //$NON-NLS-1$
+    }
+    
+    private String renderDocType(DocType docType) {
+        return " " + docType.accept(new DocTypeRenderer()); //$NON-NLS-1$
+    }
+    
+    private Stream<String> renderRootElement(Document document) {
+        return document.getRootElement().accept(new ElementRenderer());
+    }
+}

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/xml/render/ElementRenderer.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/xml/render/ElementRenderer.java
@@ -1,0 +1,89 @@
+/**
+ *    Copyright 2006-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.generator.api.dom.xml.render;
+
+import java.util.stream.Stream;
+
+import org.mybatis.generator.api.dom.xml.Element;
+import org.mybatis.generator.api.dom.xml.ElementVisitor;
+import org.mybatis.generator.api.dom.xml.TextElement;
+import org.mybatis.generator.api.dom.xml.XmlElement;
+import org.mybatis.generator.internal.util.CustomCollectors;
+
+public class ElementRenderer implements ElementVisitor<Stream<String>> {
+    
+    private AttributeRenderer attributeRenderer = new AttributeRenderer();
+
+    @Override
+    public Stream<String> visit(TextElement element) {
+        return Stream.of(element.getContent());
+    }
+
+    @Override
+    public Stream<String> visit(XmlElement element) {
+        if (element.hasChildren()) {
+            return renderWithChildren(element);
+        } else {
+            return renderWithoutChildren(element);
+        }
+    }
+
+    private Stream<String> renderWithoutChildren(XmlElement element) {
+        return Stream.of("<" //$NON-NLS-1$
+                + element.getName()
+                + renderAttributes(element)
+                + " />"); //$NON-NLS-1$
+    }
+
+    public Stream<String> renderWithChildren(XmlElement element) {
+        return Stream.of(renderOpen(element), renderChildren(element), renderClose(element))
+                .flatMap(s -> s);
+    }
+
+    private String renderAttributes(XmlElement element) {
+        return element.getAttributes().stream()
+                .sorted()
+                .map(attributeRenderer::render)
+                .collect(CustomCollectors.joining(" ", " ", "")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+    }
+
+    private Stream<String> renderOpen(XmlElement element) {
+        return Stream.of("<" //$NON-NLS-1$
+                + element.getName()
+                + renderAttributes(element)
+                + ">"); //$NON-NLS-1$
+    }
+
+    private Stream<String> renderChildren(XmlElement element) {
+        return element.getElements().stream()
+                .flatMap(this::renderChild)
+                .map(this::indent);
+    }
+
+    private Stream<String> renderChild(Element child) {
+        return child.accept(this);
+    }
+
+    private String indent(String s) {
+        return "  " + s; //$NON-NLS-1$
+    }
+
+    private Stream<String> renderClose(XmlElement element) {
+        return Stream.of("</" //$NON-NLS-1$
+                + element.getName()
+                + ">"); //$NON-NLS-1$
+    }
+}

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/AbstractJavaGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/AbstractJavaGenerator.java
@@ -29,6 +29,7 @@ import org.mybatis.generator.config.PropertyRegistry;
 
 public abstract class AbstractJavaGenerator extends AbstractGenerator {
     public abstract List<CompilationUnit> getCompilationUnits();
+    
     private String project;
     
     public AbstractJavaGenerator(String project) {

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/CountByExampleMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/CountByExampleMethodGenerator.java
@@ -46,6 +46,7 @@ public class CountByExampleMethodGenerator extends
 
         Method method = new Method(introspectedTable.getCountByExampleStatementId());
         method.setVisibility(JavaVisibility.PUBLIC);
+        method.setAbstract(true);
         method.setReturnType(new FullyQualifiedJavaType("long")); //$NON-NLS-1$
         method.addParameter(new Parameter(fqjt, "example")); //$NON-NLS-1$
         context.getCommentGenerator().addGeneralMethodComment(method,

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/DeleteByExampleMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/DeleteByExampleMethodGenerator.java
@@ -45,6 +45,7 @@ public class DeleteByExampleMethodGenerator extends
 
         Method method = new Method(introspectedTable.getDeleteByExampleStatementId());
         method.setVisibility(JavaVisibility.PUBLIC);
+        method.setAbstract(true);
         method.setReturnType(FullyQualifiedJavaType.getIntInstance());
         method.addParameter(new Parameter(type, "example")); //$NON-NLS-1$
 

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/DeleteByPrimaryKeyMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/DeleteByPrimaryKeyMethodGenerator.java
@@ -46,6 +46,7 @@ public class DeleteByPrimaryKeyMethodGenerator extends
         Set<FullyQualifiedJavaType> importedTypes = new TreeSet<>();
         Method method = new Method(introspectedTable.getDeleteByPrimaryKeyStatementId());
         method.setVisibility(JavaVisibility.PUBLIC);
+        method.setAbstract(true);
         method.setReturnType(FullyQualifiedJavaType.getIntInstance());
 
         if (!isSimple && introspectedTable.getRules().generatePrimaryKeyClass()) {

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/InsertMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/InsertMethodGenerator.java
@@ -44,6 +44,7 @@ public class InsertMethodGenerator extends AbstractJavaMapperMethodGenerator {
 
         method.setReturnType(FullyQualifiedJavaType.getIntInstance());
         method.setVisibility(JavaVisibility.PUBLIC);
+        method.setAbstract(true);
 
         FullyQualifiedJavaType parameterType;
         if (isSimple) {

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/InsertSelectiveMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/InsertSelectiveMethodGenerator.java
@@ -42,6 +42,7 @@ public class InsertSelectiveMethodGenerator extends
 
         method.setReturnType(FullyQualifiedJavaType.getIntInstance());
         method.setVisibility(JavaVisibility.PUBLIC);
+        method.setAbstract(true);
 
         FullyQualifiedJavaType parameterType = introspectedTable.getRules()
                 .calculateAllFieldsClass();

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/SelectAllMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/SelectAllMethodGenerator.java
@@ -42,6 +42,7 @@ public class SelectAllMethodGenerator extends AbstractJavaMapperMethodGenerator 
 
         Method method = new Method(introspectedTable.getSelectAllStatementId());
         method.setVisibility(JavaVisibility.PUBLIC);
+        method.setAbstract(true);
 
         FullyQualifiedJavaType returnType = FullyQualifiedJavaType
                 .getNewListInstance();

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/SelectByExampleWithBLOBsMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/SelectByExampleWithBLOBsMethodGenerator.java
@@ -47,6 +47,7 @@ public class SelectByExampleWithBLOBsMethodGenerator extends
         Method method = new Method(introspectedTable
                 .getSelectByExampleWithBLOBsStatementId());
         method.setVisibility(JavaVisibility.PUBLIC);
+        method.setAbstract(true);
 
         FullyQualifiedJavaType returnType = FullyQualifiedJavaType
                 .getNewListInstance();

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/SelectByExampleWithoutBLOBsMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/SelectByExampleWithoutBLOBsMethodGenerator.java
@@ -48,6 +48,7 @@ public class SelectByExampleWithoutBLOBsMethodGenerator extends
 
         Method method = new Method(introspectedTable.getSelectByExampleStatementId());
         method.setVisibility(JavaVisibility.PUBLIC);
+        method.setAbstract(true);
 
         FullyQualifiedJavaType returnType = FullyQualifiedJavaType
                 .getNewListInstance();

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/SelectByPrimaryKeyMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/SelectByPrimaryKeyMethodGenerator.java
@@ -46,6 +46,7 @@ public class SelectByPrimaryKeyMethodGenerator extends
         Set<FullyQualifiedJavaType> importedTypes = new TreeSet<>();
         Method method = new Method(introspectedTable.getSelectByPrimaryKeyStatementId());
         method.setVisibility(JavaVisibility.PUBLIC);
+        method.setAbstract(true);
 
         FullyQualifiedJavaType returnType = introspectedTable.getRules()
                 .calculateAllFieldsClass();

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/UpdateByExampleSelectiveMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/UpdateByExampleSelectiveMethodGenerator.java
@@ -37,6 +37,7 @@ public class UpdateByExampleSelectiveMethodGenerator extends
         Method method = new Method(introspectedTable
                 .getUpdateByExampleSelectiveStatementId());
         method.setVisibility(JavaVisibility.PUBLIC);
+        method.setAbstract(true);
         method.setReturnType(FullyQualifiedJavaType.getIntInstance());
 
         FullyQualifiedJavaType parameterType =

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/UpdateByExampleWithBLOBsMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/UpdateByExampleWithBLOBsMethodGenerator.java
@@ -41,6 +41,7 @@ public class UpdateByExampleWithBLOBsMethodGenerator extends
         Method method = new Method(introspectedTable
                 .getUpdateByExampleWithBLOBsStatementId());
         method.setVisibility(JavaVisibility.PUBLIC);
+        method.setAbstract(true);
         method.setReturnType(FullyQualifiedJavaType.getIntInstance());
 
         FullyQualifiedJavaType parameterType;

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/UpdateByExampleWithoutBLOBsMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/UpdateByExampleWithoutBLOBsMethodGenerator.java
@@ -40,6 +40,7 @@ public class UpdateByExampleWithoutBLOBsMethodGenerator extends
     public void addInterfaceElements(Interface interfaze) {
         Method method = new Method(introspectedTable.getUpdateByExampleStatementId());
         method.setVisibility(JavaVisibility.PUBLIC);
+        method.setAbstract(true);
         method.setReturnType(FullyQualifiedJavaType.getIntInstance());
 
         FullyQualifiedJavaType parameterType;

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/UpdateByPrimaryKeySelectiveMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/UpdateByPrimaryKeySelectiveMethodGenerator.java
@@ -54,6 +54,7 @@ public class UpdateByPrimaryKeySelectiveMethodGenerator extends
         Method method = new Method(introspectedTable
                 .getUpdateByPrimaryKeySelectiveStatementId());
         method.setVisibility(JavaVisibility.PUBLIC);
+        method.setAbstract(true);
         method.setReturnType(FullyQualifiedJavaType.getIntInstance());
         method.addParameter(new Parameter(parameterType, "record")); //$NON-NLS-1$
 

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/UpdateByPrimaryKeyWithBLOBsMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/UpdateByPrimaryKeyWithBLOBsMethodGenerator.java
@@ -54,6 +54,7 @@ public class UpdateByPrimaryKeyWithBLOBsMethodGenerator extends
         Method method = new Method(introspectedTable
                 .getUpdateByPrimaryKeyWithBLOBsStatementId());
         method.setVisibility(JavaVisibility.PUBLIC);
+        method.setAbstract(true);
         method.setReturnType(FullyQualifiedJavaType.getIntInstance());
 
         method.addParameter(new Parameter(parameterType, "record")); //$NON-NLS-1$

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/UpdateByPrimaryKeyWithoutBLOBsMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/UpdateByPrimaryKeyWithoutBLOBsMethodGenerator.java
@@ -45,6 +45,7 @@ public class UpdateByPrimaryKeyWithoutBLOBsMethodGenerator extends
 
         Method method = new Method(introspectedTable.getUpdateByPrimaryKeyStatementId());
         method.setVisibility(JavaVisibility.PUBLIC);
+        method.setAbstract(true);
         method.setReturnType(FullyQualifiedJavaType.getIntInstance());
         method.addParameter(new Parameter(parameterType, "record")); //$NON-NLS-1$
 

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/model/PrimaryKeyGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/model/PrimaryKeyGenerator.java
@@ -63,8 +63,9 @@ public class PrimaryKeyGenerator extends AbstractJavaGenerator {
 
         String rootClass = getRootClass();
         if (rootClass != null) {
-            topLevelClass.setSuperClass(new FullyQualifiedJavaType(rootClass));
-            topLevelClass.addImportedType(topLevelClass.getSuperClass());
+            FullyQualifiedJavaType rootType = new FullyQualifiedJavaType(rootClass);
+            topLevelClass.setSuperClass(rootType);
+            topLevelClass.addImportedType(rootType);
         }
 
         if (introspectedTable.isConstructorBased()) {

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/internal/util/CustomCollectors.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/internal/util/CustomCollectors.java
@@ -1,0 +1,43 @@
+/**
+ *    Copyright 2006-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.generator.internal.util;
+
+import java.util.StringJoiner;
+import java.util.stream.Collector;
+
+public interface CustomCollectors {
+
+    /**
+     * Returns a {@code Collector} similar to the standard JDK joining collector, except that
+     * this collector returns an empty string if there are no elements to collect.
+     *
+     * @param delimiter the delimiter to be used between each element
+     * @param  prefix the sequence of characters to be used at the beginning
+     *                of the joined result
+     * @param  suffix the sequence of characters to be used at the end
+     *                of the joined result
+     * @return A {@code Collector} which concatenates CharSequence elements,
+     *     separated by the specified delimiter, in encounter order
+     */
+    static Collector<CharSequence, StringJoiner, String> joining(CharSequence delimiter, CharSequence prefix,
+            CharSequence suffix) {
+        return Collector.of(() -> {
+            StringJoiner sj = new StringJoiner(delimiter, prefix, suffix);
+            sj.setEmptyValue(""); //$NON-NLS-1$
+            return sj;
+        }, StringJoiner::add, StringJoiner::merge, StringJoiner::toString);
+    }
+}

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/plugins/RowBoundsPlugin.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/plugins/RowBoundsPlugin.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.mybatis.generator.api.FullyQualifiedTable;
 import org.mybatis.generator.api.IntrospectedTable;
@@ -116,11 +117,12 @@ public class RowBoundsPlugin extends PluginAdapter {
         return true;
     }
 
-    private void addNewComposedFunction(Interface interfaze, IntrospectedTable introspectedTable, FullyQualifiedJavaType baseMethodReturnType) {
+    private void addNewComposedFunction(Interface interfaze, IntrospectedTable introspectedTable,
+            Optional<FullyQualifiedJavaType> baseMethodReturnType) {
         interfaze.addImportedType(new FullyQualifiedJavaType("java.util.function.Function")); //$NON-NLS-1$
         
         FullyQualifiedJavaType returnType = new FullyQualifiedJavaType("Function<SelectStatementProvider, " //$NON-NLS-1$
-                + baseMethodReturnType.getShortName() + ">"); //$NON-NLS-1$
+                + baseMethodReturnType.get().getShortName() + ">"); //$NON-NLS-1$
         
         Method method = new Method("selectManyWithRowbounds"); //$NON-NLS-1$
         method.setDefault(true);

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/elements/BasicCountMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/elements/BasicCountMethodGenerator.java
@@ -46,6 +46,7 @@ public class BasicCountMethodGenerator extends AbstractMethodGenerator {
         imports.add(annotation);
         
         Method method = new Method("count"); //$NON-NLS-1$
+        method.setAbstract(true);
         method.setReturnType(new FullyQualifiedJavaType("long")); //$NON-NLS-1$
         method.addParameter(new Parameter(parameterType, "selectStatement")); //$NON-NLS-1$
         context.getCommentGenerator().addGeneralMethodAnnotation(method, introspectedTable, imports);

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/elements/BasicDeleteMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/elements/BasicDeleteMethodGenerator.java
@@ -47,6 +47,7 @@ public class BasicDeleteMethodGenerator extends AbstractMethodGenerator {
         imports.add(annotation);
         
         Method method = new Method("delete"); //$NON-NLS-1$
+        method.setAbstract(true);
         method.setReturnType(FullyQualifiedJavaType.getIntInstance());
         method.addParameter(new Parameter(parameterType, "deleteStatement")); //$NON-NLS-1$
         context.getCommentGenerator().addGeneralMethodAnnotation(method, introspectedTable, imports);

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/elements/BasicInsertMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/elements/BasicInsertMethodGenerator.java
@@ -56,6 +56,7 @@ public class BasicInsertMethodGenerator extends AbstractMethodGenerator {
         parameterType.addTypeArgument(recordType);
         
         Method method = new Method("insert"); //$NON-NLS-1$
+        method.setAbstract(true);
         method.setReturnType(FullyQualifiedJavaType.getIntInstance());
         method.addParameter(new Parameter(parameterType, "insertStatement")); //$NON-NLS-1$
         context.getCommentGenerator().addGeneralMethodAnnotation(method, introspectedTable, imports);

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/elements/BasicSelectManyMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/elements/BasicSelectManyMethodGenerator.java
@@ -56,6 +56,7 @@ public class BasicSelectManyMethodGenerator extends AbstractMethodGenerator {
         FullyQualifiedJavaType returnType = FullyQualifiedJavaType.getNewListInstance();
         returnType.addTypeArgument(recordType);
         Method method = new Method("selectMany"); //$NON-NLS-1$
+        method.setAbstract(true);
         method.setReturnType(returnType);
         method.addParameter(new Parameter(parameterType, "selectStatement")); //$NON-NLS-1$
         context.getCommentGenerator().addGeneralMethodAnnotation(method, introspectedTable, imports);

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/elements/BasicSelectOneMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/elements/BasicSelectOneMethodGenerator.java
@@ -56,6 +56,7 @@ public class BasicSelectOneMethodGenerator extends AbstractMethodGenerator {
         imports.add(annotation);
         
         Method method = new Method("selectOne"); //$NON-NLS-1$
+        method.setAbstract(true);
 
         imports.add(recordType);
         method.setReturnType(recordType);

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/elements/BasicUpdateMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/elements/BasicUpdateMethodGenerator.java
@@ -51,6 +51,7 @@ public class BasicUpdateMethodGenerator extends AbstractMethodGenerator {
         imports.add(annotation);
         
         Method method = new Method("update"); //$NON-NLS-1$
+        method.setAbstract(true);
         method.setReturnType(FullyQualifiedJavaType.getIntInstance());
         method.addParameter(new Parameter(parameterType, "updateStatement")); //$NON-NLS-1$
         context.getCommentGenerator().addGeneralMethodAnnotation(method, introspectedTable, imports);

--- a/core/mybatis-generator-core/src/main/resources/org/mybatis/generator/internal/util/messages/messages.properties
+++ b/core/mybatis-generator-core/src/main/resources/org/mybatis/generator/internal/util/messages/messages.properties
@@ -54,7 +54,6 @@ RuntimeError.6=Cannot instantiate object of type {0}
 RuntimeError.7=Cannot connect to database (possibly bad driver/URL combination)
 RuntimeError.8=Exception getting JDBC Driver
 RuntimeError.9=Cannot resolve classpath entry: {0}
-RuntimeError.11=Enumerations do not have super classes 
 RuntimeError.12=Internal Error - Cannot calculate record type for selectByExample method
 RuntimeError.13=Invalid model type: {0}
 RuntimeError.14=Either resource or URL is required on the <properties> element, but not both

--- a/core/mybatis-generator-core/src/site/xhtml/whatsNew.xhtml
+++ b/core/mybatis-generator-core/src/site/xhtml/whatsNew.xhtml
@@ -26,15 +26,40 @@
 <body>
 <h1>What's New in MyBatis Generator</h1>
 <h2>Version 1.4.0</h2>
+<p>This is a fairly major change with these themes:</p>
+<ul>
+  <li>Move to Java 8</li>
+  <li>Remove support for iBatis2</li>
+  <li>General code cleanup</li>
+</ul>
+
+<h3>Breaking API Changes</h3>
+<ul>
+  <li>Removed Plugin methods that were specific to iBatis2 (these were the <code>clientXXXGenerated</code>
+      methods that accepted a <code>TopLevelClass</code> as a parameter).</li>
+  <li>Changed the signature of the Plugin <code>clientGenerated</code> method.</li>
+  <li>Removed the <code>toXmlElement</code> methods in the configuration classes. These methods were never properly
+      implemented.</li>
+  <li>In the Java DOM, the <code>Method</code> class now requires an explicit call to <code>setAbstract</code>
+      to mark the method as an abstract method. This was done to support private methods in interfaces for Java9+
+      code.</li>
+  <li>In the Java DOM, removed the default constructors for <code>Method</code> and <code>Field</code></li>
+  <li>Removed several methods from <code>CompilationUnit</code> including <code>isJavaInterface</code>,
+      <code>isJavaEnumeration</code>, <code>getSuperClass</code>, and <code>getSuperInterfaceTypes</code>.</li>
+  <li>Changed return types to Optionals in the DOM methods where appropriate.</li>
+  <li>Removed the <code>getFormattedContent</code> method from all Java and XML DOM classes. These methods
+      are replaced by a new set of renderer classes. Note that the new renderer classes will produce
+      code that is the same as the prior methods with very few exceptions - and those exceptions are related to
+      bugs in the old methods.</li>
+</ul>
+
+<h3>Other Changes</h3>
 <ul>
   <li>Support for iBatis2 removed</li>
   <li>Support for parsing old Ibator configuration files removed</li>
   <li>Removed SqlMapConfigPlugin as that was specific to iBatis2</li>
   <li>Added ability to specify a different project and package for generated model objects</li>
-  <li>Removed Plugin methods that were specific to iBatis2. Also changed the signature of
-      the Plugin <code>clientGenerated</code> method.</li>
-  <li>Removed the <code>toXmlElement</code> methods in the configuration classes. These methods were never properly
-      implemented.</li>
+  <li>Expanded the capabilities of the Java DOM and fixed a few inconsistencies</li>
 </ul>
 
 <h2>Version 1.3.7</h2>

--- a/core/mybatis-generator-core/src/test/java/org/mybatis/generator/JavaCodeGenerationTest.java
+++ b/core/mybatis-generator-core/src/test/java/org/mybatis/generator/JavaCodeGenerationTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mybatis.generator.api.GeneratedJavaFile;
 import org.mybatis.generator.api.MyBatisGenerator;
+import org.mybatis.generator.api.dom.DefaultJavaFormatter;
 import org.mybatis.generator.config.Configuration;
 import org.mybatis.generator.config.xml.ConfigurationParser;
 import org.mybatis.generator.internal.DefaultShellCallback;
@@ -37,8 +38,10 @@ public class JavaCodeGenerationTest {
     @ParameterizedTest
     @MethodSource("generateJavaFiles")
     public void testJavaParse(GeneratedJavaFile generatedJavaFile) {
+        DefaultJavaFormatter formatter = new DefaultJavaFormatter();
+
         ByteArrayInputStream is = new ByteArrayInputStream(
-                generatedJavaFile.getCompilationUnit().getFormattedContent().getBytes());
+                formatter.getFormattedContent(generatedJavaFile.getCompilationUnit()).getBytes());
         try {
             JavaParser.parse(is);
         } catch (ParseProblemException e) {

--- a/core/mybatis-generator-core/src/test/java/org/mybatis/generator/api/dom/java/FullyQualifiedJavaTypeTest.java
+++ b/core/mybatis-generator-core/src/test/java/org/mybatis/generator/api/dom/java/FullyQualifiedJavaTypeTest.java
@@ -15,13 +15,11 @@
  */
 package org.mybatis.generator.api.dom.java;
 
-import static org.junit.jupiter.api.Assertions.*;
-
-import java.util.Set;
-import java.util.TreeSet;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
-import org.mybatis.generator.api.dom.OutputUtilities;
 
 /**
  * @author Jeff Butler
@@ -224,19 +222,6 @@ public class FullyQualifiedJavaTypeTest {
         assertEquals(2, fqjt.getImportList().size());
         assertTrue(fqjt.getImportList().contains("java.util.List"));
         assertTrue(fqjt.getImportList().contains("org.foo.Bar.Inner"));
-    }
-
-    @Test
-    public void testImportList() {
-        Set<FullyQualifiedJavaType> types = new TreeSet<>();
-
-        types.add(new FullyQualifiedJavaType("foo.bar.Example"));
-        types.add(new FullyQualifiedJavaType("foo.bar.Example.Criteria"));
-        types.add(new FullyQualifiedJavaType("foo.bar.Example.Criterion"));
-        assertEquals(3, types.size());
-
-        Set<String> imports = OutputUtilities.calculateImports(types);
-        assertEquals(3, imports.size());
     }
 
     @Test

--- a/core/mybatis-generator-core/src/test/java/org/mybatis/generator/api/dom/java/InnerClassTest.java
+++ b/core/mybatis-generator-core/src/test/java/org/mybatis/generator/api/dom/java/InnerClassTest.java
@@ -17,7 +17,10 @@ package org.mybatis.generator.api.dom.java;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.stream.Collectors;
+
 import org.junit.jupiter.api.Test;
+import org.mybatis.generator.api.dom.java.render.InnerClassRenderer;
 
 public class InnerClassTest {
 
@@ -29,7 +32,7 @@ public class InnerClassTest {
 
         assertNotNull(clazz);
 
-        assertNull(clazz.getSuperClass());
+        assertFalse(clazz.getSuperClass().isPresent());
 
         assertNotNull(clazz.getType());
         assertEquals("com.foo.UserClass", clazz.getType().getFullyQualifiedName());
@@ -73,10 +76,10 @@ public class InnerClassTest {
     public void testSetSuperClass() {
         InnerClass clazz = new InnerClass("com.foo.UserClass");
 
-        assertNull(clazz.getSuperClass());
+        assertFalse(clazz.getSuperClass().isPresent());
         clazz.setSuperClass("com.hoge.SuperClass");
         assertNotNull(clazz.getSuperClass());
-        assertEquals("com.hoge.SuperClass", clazz.getSuperClass().getFullyQualifiedName());
+        assertEquals("com.hoge.SuperClass", clazz.getSuperClass().get().getFullyQualifiedName());
     }
 
     @Test
@@ -156,17 +159,20 @@ public class InnerClassTest {
 
     @Test
     public void testGetFormattedContent() {
-        InnerClass clazz = new InnerClass("com.foo.UserClass");
-        clazz.addField(new Field("test", FullyQualifiedJavaType.getStringInstance()));
-        clazz.setSuperClass("com.hoge.SuperClass");
-        clazz.addInnerClass(new InnerClass("InnerUserClass"));
-        clazz.addInnerEnum(new InnerEnum(new FullyQualifiedJavaType("TestEnum")));
-        clazz.addTypeParameter(new TypeParameter("T"));
-        clazz.addTypeParameter(new TypeParameter("U"));
-        clazz.addInitializationBlock(new InitializationBlock(false));
-        clazz.addSuperInterface(new FullyQualifiedJavaType("com.hoge.UserInterface"));
-        clazz.addMethod(new Method("method1"));
-        clazz.setAbstract(true);
+        InnerClass innerClass = new InnerClass("com.foo.UserClass");
+        innerClass.addField(new Field("test", FullyQualifiedJavaType.getStringInstance()));
+        innerClass.setSuperClass("com.hoge.SuperClass");
+        innerClass.addInnerClass(new InnerClass("InnerUserClass"));
+        innerClass.addInnerEnum(new InnerEnum(new FullyQualifiedJavaType("TestEnum")));
+        innerClass.addTypeParameter(new TypeParameter("T"));
+        innerClass.addTypeParameter(new TypeParameter("U"));
+        innerClass.addInitializationBlock(new InitializationBlock(false));
+        innerClass.addSuperInterface(new FullyQualifiedJavaType("com.hoge.UserInterface"));
+        
+        Method method = new Method("method1");
+        method.setAbstract(true);
+        innerClass.addMethod(method);
+        innerClass.setAbstract(true);
 
         String excepted = "abstract class UserClass<T, U>  extends SuperClass implements UserInterface {" + LF
                 + "    String test;" + LF
@@ -183,6 +189,8 @@ public class InnerClassTest {
                 + "    }" + LF
                 + "}";
 
-        assertEquals(excepted, clazz.getFormattedContent(0, null));
+        InnerClassRenderer renderer = new InnerClassRenderer();
+        String rendered = renderer.render(innerClass, null).stream().collect(Collectors.joining(LF));
+        assertEquals(excepted, rendered);
     }
 }

--- a/core/mybatis-generator-core/src/test/java/org/mybatis/generator/api/dom/java/InnerInterfaceTest.java
+++ b/core/mybatis-generator-core/src/test/java/org/mybatis/generator/api/dom/java/InnerInterfaceTest.java
@@ -59,35 +59,14 @@ public class InnerInterfaceTest {
     }
 
     @Test
-    public void testGetSuperClass() {
-
-        InnerInterface interfaze = new InnerInterface("com.foo.UserInterface");
-        assertNull(interfaze.getSuperClass());
-    }
-
-    @Test
     public void testAddInnerInterfaces() {
 
         InnerInterface interfaze = new InnerInterface("com.foo.UserInterface");
         InnerInterface innerInterfaze = new InnerInterface("com.foo.InnerUserInterface");
 
-        interfaze.addInnerInterfaces(innerInterfaze);
+        interfaze.addInnerInterface(innerInterfaze);
         assertNotNull(interfaze.getInnerInterfaces());
         assertEquals(interfaze.getInnerInterfaces().size(), 1);
         assertSame(interfaze.getInnerInterfaces().get(0), innerInterfaze);
-    }
-
-    @Test
-    public void testIsJavaInterface() {
-
-        InnerInterface interfaze = new InnerInterface("com.foo.UserInterface");
-        assertTrue(interfaze.isJavaInterface());
-    }
-
-    @Test
-    public void testIsJavaEnumeration() {
-
-        InnerInterface interfaze = new InnerInterface("com.foo.UserInterface");
-        assertFalse(interfaze.isJavaEnumeration());
     }
 }

--- a/core/mybatis-generator-core/src/test/java/org/mybatis/generator/api/dom/java/InterfaceTest.java
+++ b/core/mybatis-generator-core/src/test/java/org/mybatis/generator/api/dom/java/InterfaceTest.java
@@ -22,6 +22,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
+import org.mybatis.generator.api.dom.java.render.TopLevelInterfaceRenderer;
 
 public class InterfaceTest {
 
@@ -116,10 +117,11 @@ public class InterfaceTest {
         String expected = "package foo;" + System.getProperty("line.separator")
             + System.getProperty("line.separator")
             + "public interface Bar {" + System.getProperty("line.separator")
-            + "    String EMPTY_STRING = \"\";" + System.getProperty("line.separator")
+            + "    String EMPTY_STRING = \"\";" + System.getProperty("line.separator") + System.getProperty("line.separator")
             + "    String ONE = \"one\";" + System.getProperty("line.separator")
             + "}";
 
-        assertThat(interfaze.getFormattedContent()).isEqualTo(expected);
+        TopLevelInterfaceRenderer renderer = new TopLevelInterfaceRenderer();
+        assertThat(renderer.render(interfaze)).isEqualTo(expected);
     }
 }

--- a/core/mybatis-generator-core/src/test/java/org/mybatis/generator/api/dom/java/MethodTest.java
+++ b/core/mybatis-generator-core/src/test/java/org/mybatis/generator/api/dom/java/MethodTest.java
@@ -19,8 +19,10 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
+import org.mybatis.generator.api.dom.java.render.MethodRenderer;
 
 public class MethodTest {
 
@@ -162,10 +164,10 @@ public class MethodTest {
     public void testSetReturnType() {
 
         Method method = new Method("bar");
-        assertNull(method.getReturnType());
+        assertFalse(method.getReturnType().isPresent());
 
         method.setReturnType(FullyQualifiedJavaType.getIntInstance());
-        assertEquals(FullyQualifiedJavaType.getIntInstance(), method.getReturnType());
+        assertEquals(FullyQualifiedJavaType.getIntInstance(), method.getReturnType().get());
     }
 
     @Test
@@ -231,6 +233,8 @@ public class MethodTest {
                         + "    return func.apply(t);" + LINE_SEPARATOR
                         + "}";
 
-        assertEquals(excepted, method.getFormattedContent(0, false, null));
+        MethodRenderer renderer = new MethodRenderer();
+        String rendered = renderer.render(method, false, null).stream().collect(Collectors.joining(LINE_SEPARATOR));
+        assertEquals(excepted, rendered);
     }
 }

--- a/core/mybatis-generator-core/src/test/java/org/mybatis/generator/api/dom/java/TypeParameterTest.java
+++ b/core/mybatis-generator-core/src/test/java/org/mybatis/generator/api/dom/java/TypeParameterTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
+import org.mybatis.generator.api.dom.java.render.TypeParameterRenderer;
 
 public class TypeParameterTest {
 
@@ -48,19 +49,20 @@ public class TypeParameterTest {
 
     @Test
     public void testGetFormattedContent() {
+        TypeParameterRenderer renderer = new TypeParameterRenderer();
 
         FullyQualifiedJavaType list = FullyQualifiedJavaType.getNewListInstance();
         FullyQualifiedJavaType compare = new FullyQualifiedJavaType("java.util.Comparator");
 
         TypeParameter typeParameter = new TypeParameter("T", Arrays.asList(list, compare));
         assertNotNull(typeParameter);
-        assertEquals("T extends List & Comparator", typeParameter.getFormattedContent(null));
+        assertEquals("T extends List & Comparator", renderer.render(typeParameter, null));
 
         TopLevelClass compilationUnit = new TopLevelClass("java.util.Test");
-        assertEquals("T extends List & Comparator", typeParameter.getFormattedContent(compilationUnit));
+        assertEquals("T extends List & Comparator", renderer.render(typeParameter, compilationUnit));
 
         TopLevelClass compilationUnit2 = new TopLevelClass("java.lang.Test");
-        assertEquals("T extends java.util.List & java.util.Comparator", typeParameter.getFormattedContent(compilationUnit2));
+        assertEquals("T extends java.util.List & java.util.Comparator", renderer.render(typeParameter, compilationUnit2));
     }
 
     @Test

--- a/core/mybatis-generator-core/src/test/kotlin/org/mybatis/generator/api/dom/java/render/FieldRendererTest.kt
+++ b/core/mybatis-generator-core/src/test/kotlin/org/mybatis/generator/api/dom/java/render/FieldRendererTest.kt
@@ -1,0 +1,88 @@
+/**
+ *    Copyright 2006-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.generator.api.dom.java.render
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mybatis.generator.api.dom.java.Field
+import org.mybatis.generator.api.dom.java.FullyQualifiedJavaType
+import org.mybatis.generator.api.dom.java.JavaVisibility
+
+class FieldRendererTest {
+    @Test
+    fun testBasicField() {
+        val f = Field("name", FullyQualifiedJavaType.getStringInstance())
+        assertThat(toString(f)).isEqualTo("String name;")
+    }
+
+    @Test
+    fun testBasicFieldWithInitializationString() {
+        val f = Field("name", FullyQualifiedJavaType.getStringInstance())
+        f.setInitializationString(""""Fred"""")
+        assertThat(toString(f)).isEqualTo("""String name = "Fred";""")
+    }
+
+    @Test
+    fun testPrivateFieldWithInitializationString() {
+        val f = Field("name", FullyQualifiedJavaType.getStringInstance())
+        f.setVisibility(JavaVisibility.PRIVATE)
+        f.setInitializationString(""""Fred"""")
+        assertThat(toString(f)).isEqualTo("""private String name = "Fred";""")
+    }
+
+    @Test
+    fun testPrivateStaticFieldWithInitializationString() {
+        val f = Field("name", FullyQualifiedJavaType.getStringInstance())
+        f.setVisibility(JavaVisibility.PRIVATE)
+	f.setStatic(true)
+	f.setFinal(true)
+        f.setInitializationString(""""Fred"""")
+        assertThat(toString(f)).isEqualTo("""private static final String name = "Fred";""")
+    }
+
+    @Test
+    fun testPrivateTransientFieldWithInitializationString() {
+        val f = Field("name", FullyQualifiedJavaType.getStringInstance())
+        f.setVisibility(JavaVisibility.PRIVATE)
+	f.setTransient(true)
+	f.setVolatile(true)
+        f.setInitializationString(""""Fred"""")
+        assertThat(toString(f)).isEqualTo("""private transient volatile String name = "Fred";""")
+    }
+
+    @Test
+    fun testPrivateFieldWithInitializationStringJavadocAndAnnotations() {
+        val f = Field("name", FullyQualifiedJavaType.getStringInstance())
+        f.setVisibility(JavaVisibility.PRIVATE)
+        f.setInitializationString(""""Fred"""")
+	
+	f.addAnnotation("@Generated")
+	f.addJavaDocLine("/**")
+	f.addJavaDocLine(" * Some Javadoc")
+	f.addJavaDocLine(" */")
+		
+        assertThat(toString(f)).isEqualTo("""
+                |/**
+                | * Some Javadoc
+                | */
+                |@Generated
+                |private String name = "Fred";
+                """.trimMargin())
+    }
+
+    private fun toString(f: Field) = FieldRenderer().render(f, null)
+                .joinToString(System.getProperty("line.separator"))
+}

--- a/core/mybatis-generator-core/src/test/kotlin/org/mybatis/generator/api/dom/java/render/InitializationBlockRendererTest.kt
+++ b/core/mybatis-generator-core/src/test/kotlin/org/mybatis/generator/api/dom/java/render/InitializationBlockRendererTest.kt
@@ -1,0 +1,64 @@
+/**
+ *    Copyright 2006-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.generator.api.dom.java.render
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mybatis.generator.api.dom.java.InitializationBlock
+
+class InitializationBlockRendererTest {
+
+    @Test
+    fun testStaticBlock() {
+        val block = InitializationBlock(true)
+
+	block.addJavaDocLine("/**")
+	block.addJavaDocLine(" * Some Javadoc")
+	block.addJavaDocLine(" */")
+	block.addBodyLine("i = 3;")
+
+        assertThat(toString(block)).isEqualTo("""
+                |/**
+                | * Some Javadoc
+                | */
+                |static {
+                |    i = 3;
+                |}
+                """.trimMargin())
+    }
+
+    @Test
+    fun testNonStaticBlock() {
+        val block = InitializationBlock()
+
+	block.addJavaDocLine("/**")
+	block.addJavaDocLine(" * Some Javadoc")
+	block.addJavaDocLine(" */")
+	block.addBodyLine("i = 3;")
+
+        assertThat(toString(block)).isEqualTo("""
+                |/**
+                | * Some Javadoc
+                | */
+                |{
+                |    i = 3;
+                |}
+                """.trimMargin())
+    }
+
+    private fun toString(b: InitializationBlock) = InitializationBlockRenderer().render(b)
+                .joinToString(System.getProperty("line.separator"))
+}

--- a/core/mybatis-generator-core/src/test/kotlin/org/mybatis/generator/api/dom/java/render/InnerEnumRendererTest.kt
+++ b/core/mybatis-generator-core/src/test/kotlin/org/mybatis/generator/api/dom/java/render/InnerEnumRendererTest.kt
@@ -1,0 +1,136 @@
+/**
+ *    Copyright 2006-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.generator.api.dom.java.render
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mybatis.generator.api.dom.java.Field
+import org.mybatis.generator.api.dom.java.FullyQualifiedJavaType
+import org.mybatis.generator.api.dom.java.InnerClass
+import org.mybatis.generator.api.dom.java.InnerEnum
+import org.mybatis.generator.api.dom.java.InnerInterface
+import org.mybatis.generator.api.dom.java.JavaVisibility
+import org.mybatis.generator.api.dom.java.Method
+import org.mybatis.generator.api.dom.java.Parameter
+import org.mybatis.generator.api.dom.java.TopLevelEnumeration
+
+class InnerEnumRendererTest {
+    @Test
+    fun testSimpleEnum() {
+        val outerEnum = InnerEnum("com.foo.Bar")
+	outerEnum.setVisibility(JavaVisibility.PUBLIC)
+        outerEnum.addEnumConstant("ONE")
+        outerEnum.addEnumConstant("TWO")
+        outerEnum.addEnumConstant("THREE")
+
+        assertThat(toString(outerEnum)).isEqualTo("""
+                |public enum Bar {
+                |    ONE,
+                |    TWO,
+                |    THREE;
+                |}
+                """.trimMargin())
+    }
+
+    @Test
+    fun testComplexEnum() {
+        val outerEnum = TopLevelEnumeration("com.foo.Bar")
+	outerEnum.setVisibility(JavaVisibility.PUBLIC)
+        outerEnum.addEnumConstant("""ONE("One")""")
+        outerEnum.addEnumConstant("""TWO("Two")""")
+        outerEnum.addEnumConstant("""THREE("Three")""")
+	val constructor = Method("Bar")
+	constructor.setConstructor(true)
+	constructor.setVisibility(JavaVisibility.PRIVATE)
+	constructor.addParameter(Parameter(FullyQualifiedJavaType.getStringInstance(), "value"))
+	constructor.addBodyLine("this.value = value;")
+	outerEnum.addMethod(constructor)
+	val outerField = Field("value", FullyQualifiedJavaType.getStringInstance())
+	outerField.setVisibility(JavaVisibility.PRIVATE)
+	outerEnum.addField(outerField)
+	val outerMethod = Method("getValue")
+	outerMethod.setReturnType(FullyQualifiedJavaType.getStringInstance())
+	outerMethod.setVisibility(JavaVisibility.PUBLIC)
+	outerMethod.addBodyLine("return value;")
+	outerEnum.addMethod(outerMethod)
+
+        val innerEnum = InnerEnum("InnerEnum")
+        innerEnum.setVisibility(JavaVisibility.PUBLIC)
+        innerEnum.setStatic(true)
+        innerEnum.addEnumConstant("FOUR")
+        innerEnum.addEnumConstant("FIVE")
+        innerEnum.addEnumConstant("SIX")
+        outerEnum.addInnerEnum(innerEnum)
+
+        val innerClass = InnerClass("InnerClass")
+	innerClass.setVisibility(JavaVisibility.PUBLIC)
+	innerClass.setStatic(true)
+	val field = Field("fred", FullyQualifiedJavaType.getStringInstance())
+	field.setVisibility(JavaVisibility.PRIVATE)
+	innerClass.addField(field)
+	outerEnum.addInnerClass(innerClass)
+
+        val innerInterface = InnerInterface("InnerInterface")
+	innerInterface.setVisibility(JavaVisibility.PUBLIC)
+	innerInterface.setStatic(true)
+	val method = Method("getName")
+	method.setVisibility(JavaVisibility.PUBLIC)
+	method.setDefault(true)
+	method.setReturnType(FullyQualifiedJavaType.getStringInstance())
+	method.addBodyLine("""return "Fred";""")
+	innerInterface.addMethod(method)
+	outerEnum.addInnerInterface(innerInterface)
+
+        assertThat(TopLevelEnumerationRenderer().render(outerEnum)).isEqualTo("""
+                |package com.foo;
+                |
+                |public enum Bar {
+                |    ONE("One"),
+                |    TWO("Two"),
+                |    THREE("Three");
+                |
+                |    private String value;
+                |
+                |    private Bar(String value) {
+                |        this.value = value;
+                |    }
+                |
+                |    public String getValue() {
+                |        return value;
+                |    }
+                |
+                |    public static class InnerClass {
+                |        private String fred;
+                |    }
+                |
+                |    public static interface InnerInterface {
+                |        default String getName() {
+                |            return "Fred";
+                |        }
+                |    }
+                |
+                |    public static enum InnerEnum {
+                |        FOUR,
+                |        FIVE,
+                |        SIX;
+                |    }
+                |}
+                """.trimMargin())
+    }
+
+    private fun toString(en: InnerEnum) = InnerEnumRenderer().render(en, null)
+                .joinToString(System.getProperty("line.separator"))
+}

--- a/core/mybatis-generator-core/src/test/kotlin/org/mybatis/generator/api/dom/java/render/MethodRendererTest.kt
+++ b/core/mybatis-generator-core/src/test/kotlin/org/mybatis/generator/api/dom/java/render/MethodRendererTest.kt
@@ -1,0 +1,300 @@
+/**
+ *    Copyright 2006-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.generator.api.dom.java.render
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mybatis.generator.api.dom.java.FullyQualifiedJavaType
+import org.mybatis.generator.api.dom.java.JavaVisibility
+import org.mybatis.generator.api.dom.java.Method
+import org.mybatis.generator.api.dom.java.Parameter
+import org.mybatis.generator.api.dom.java.TypeParameter
+
+class MethodRendererTest {
+
+    @Test
+    fun testSimpleGetterMethod() {
+        val method = Method("getName");
+        method.setReturnType(FullyQualifiedJavaType.getStringInstance())
+        method.setVisibility(JavaVisibility.PUBLIC)
+        method.addBodyLine("return name;")
+
+        assertThat(toString(method)).isEqualTo("""
+                |public String getName() {
+                |    return name;
+                |}
+                """.trimMargin())
+    }
+
+    @Test
+    fun testSimpleSetterMethod() {
+        val method = Method("setName");
+        method.setVisibility(JavaVisibility.PUBLIC)
+        method.addParameter(Parameter(FullyQualifiedJavaType.getStringInstance(), "name"))
+        method.addBodyLine("this.name = name;")
+
+        assertThat(toString(method)).isEqualTo("""
+                |public void setName(String name) {
+                |    this.name = name;
+                |}
+                """.trimMargin())
+    }
+
+    @Test
+    fun testMethodWithIf() {
+        val method = Method("setName");
+        method.setVisibility(JavaVisibility.PUBLIC)
+        method.addParameter(Parameter(FullyQualifiedJavaType.getStringInstance(), "name"))
+        method.addBodyLine("if(name == null) {")
+        method.addBodyLine("this.name = null;")
+        method.addBodyLine("} else {")
+        method.addBodyLine("this.name = name;")
+        method.addBodyLine("}")
+
+        assertThat(toString(method)).isEqualTo("""
+                |public void setName(String name) {
+                |    if(name == null) {
+                |        this.name = null;
+                |    } else {
+                |        this.name = name;
+                |    }
+                |}
+                """.trimMargin())
+    }
+
+    @Test
+    fun testMethodWithSwitch() {
+        val method = Method("setType");
+        method.setVisibility(JavaVisibility.PUBLIC)
+        method.addParameter(Parameter(FullyQualifiedJavaType.getIntInstance(), "type"))
+        method.addBodyLine("switch(type) {")
+        method.addBodyLine("case 1:")
+        method.addBodyLine("""this.name = "Fred";""")
+        method.addBodyLine("break;")
+        method.addBodyLine("case 2:")
+        method.addBodyLine("""this.name = "Barney";""")
+        method.addBodyLine("break;")
+        method.addBodyLine("default:")
+        method.addBodyLine("""this.name = "Wilma";""")
+        method.addBodyLine("break;")
+        method.addBodyLine("}")
+
+        assertThat(toString(method)).isEqualTo("""
+                |public void setType(int type) {
+                |    switch(type) {
+                |    case 1:
+                |        this.name = "Fred";
+                |        break;
+                |    case 2:
+                |        this.name = "Barney";
+                |        break;
+                |    default:
+                |        this.name = "Wilma";
+                |        break;
+                |    }
+                |}
+                """.trimMargin())
+    }
+
+    @Test
+    fun testTypeParameters() {
+        val method = Method("getName");
+        method.setVisibility(JavaVisibility.PUBLIC)
+        method.setReturnType(FullyQualifiedJavaType.getStringInstance())
+        method.addTypeParameter(TypeParameter("R"))
+        method.addParameter(Parameter(FullyQualifiedJavaType("R"), "name"))
+        method.addBodyLine("""return "Fred";""")
+
+        assertThat(toString(method)).isEqualTo("""
+                |public <R> String getName(R name) {
+                |    return "Fred";
+                |}
+                """.trimMargin())
+    }
+
+    @Test
+    fun testMultipleTypeParameters() {
+        val method = Method("getName");
+        method.setVisibility(JavaVisibility.PUBLIC)
+        method.setReturnType(FullyQualifiedJavaType.getStringInstance())
+        method.addTypeParameter(TypeParameter("R"))
+        method.addTypeParameter(TypeParameter("T"))
+        method.addParameter(Parameter(FullyQualifiedJavaType("R"), "name"))
+        method.addBodyLine("""return "Fred";""")
+
+        assertThat(toString(method)).isEqualTo("""
+                |public <R, T> String getName(R name) {
+                |    return "Fred";
+                |}
+                """.trimMargin())
+    }
+
+    @Test
+    fun testMultipleParameters() {
+        val method = Method("getName");
+        method.setVisibility(JavaVisibility.PUBLIC)
+        method.setReturnType(FullyQualifiedJavaType.getStringInstance())
+        method.addTypeParameter(TypeParameter("R"))
+        method.addTypeParameter(TypeParameter("T"))
+        method.addParameter(Parameter(FullyQualifiedJavaType("R"), "name"))
+        method.addParameter(Parameter(FullyQualifiedJavaType("T"), "type"))
+        method.addBodyLine("""return "Fred";""")
+
+        assertThat(toString(method)).isEqualTo("""
+                |public <R, T> String getName(R name, T type) {
+                |    return "Fred";
+                |}
+                """.trimMargin())
+    }
+
+    @Test
+    fun testExceptions() {
+        val method = Method("getName");
+        method.setVisibility(JavaVisibility.PUBLIC)
+        method.setReturnType(FullyQualifiedJavaType.getStringInstance())
+        method.addTypeParameter(TypeParameter("R"))
+        method.addParameter(Parameter(FullyQualifiedJavaType("R"), "name"))
+        method.addException(FullyQualifiedJavaType("Exception"))
+        method.addBodyLine("""return "Fred";""")
+
+        assertThat(toString(method)).isEqualTo("""
+                |public <R> String getName(R name) throws Exception {
+                |    return "Fred";
+                |}
+                """.trimMargin())
+    }
+
+    @Test
+    fun testAbstract() {
+        val method = Method("getName");
+        method.setVisibility(JavaVisibility.PUBLIC)
+        method.setReturnType(FullyQualifiedJavaType.getStringInstance())
+        method.addTypeParameter(TypeParameter("R"))
+        method.addParameter(Parameter(FullyQualifiedJavaType("R"), "name"))
+        method.addException(FullyQualifiedJavaType("Exception"))
+        method.setAbstract(true)
+        method.addBodyLine("""return "Fred";""") // should be ignored
+
+        assertThat(toString(method)).isEqualTo("""
+                |public abstract <R> String getName(R name) throws Exception;
+                """.trimMargin())
+    }
+
+    @Test
+    fun testAbstractInInterface() {
+        val method = Method("getName");
+        method.setReturnType(FullyQualifiedJavaType.getStringInstance())
+        method.addTypeParameter(TypeParameter("R"))
+        method.addParameter(Parameter(FullyQualifiedJavaType("R"), "name"))
+        method.addException(FullyQualifiedJavaType("Exception"))
+        method.setAbstract(true)
+        method.setVisibility(JavaVisibility.PUBLIC)  // should be ignored
+        method.addBodyLine("""return "Fred";""") // should be ignored
+
+        assertThat(toString(method, true)).isEqualTo("""
+                |<R> String getName(R name) throws Exception;
+                """.trimMargin())
+    }
+
+    @Test
+    fun testPrivateInInterface() {
+        val method = Method("getName");
+        method.setReturnType(FullyQualifiedJavaType.getStringInstance())
+        method.addTypeParameter(TypeParameter("R"))
+        method.addParameter(Parameter(FullyQualifiedJavaType("R"), "name"))
+        method.addException(FullyQualifiedJavaType("Exception"))
+        method.setVisibility(JavaVisibility.PRIVATE)
+        method.addBodyLine("""return "Fred";""") // should be ignored
+
+        assertThat(toString(method, true)).isEqualTo("""
+                |private <R> String getName(R name) throws Exception {
+                |    return "Fred";
+                |}
+                """.trimMargin())
+    }
+
+    @Test
+    fun testNative() {
+        val method = Method("getName");
+        method.setVisibility(JavaVisibility.PUBLIC)
+        method.setReturnType(FullyQualifiedJavaType.getStringInstance())
+        method.addTypeParameter(TypeParameter("R"))
+        method.addParameter(Parameter(FullyQualifiedJavaType("R"), "name"))
+        method.addException(FullyQualifiedJavaType("Exception"))
+        method.setNative(true)
+        method.addBodyLine("""return "Fred";""") // should be ignored
+
+        assertThat(toString(method)).isEqualTo("""
+                |public native <R> String getName(R name) throws Exception;
+                """.trimMargin())
+    }
+
+    @Test
+    fun testEmptyMethod() {
+        val method = Method("setName");
+        method.setVisibility(JavaVisibility.PUBLIC)
+        method.addParameter(Parameter(FullyQualifiedJavaType.getStringInstance(), "name"))
+
+        assertThat(toString(method)).isEqualTo("""
+                |public void setName(String name) {
+                |}
+                """.trimMargin())
+    }
+
+    @Test
+    fun testConstructor() {
+        val method = Method("MyClass");
+        method.setVisibility(JavaVisibility.PUBLIC)
+        method.setConstructor(true)
+        method.addParameter(Parameter(FullyQualifiedJavaType.getStringInstance(), "name"))
+        method.addBodyLine("super(name);")
+        method.setReturnType(FullyQualifiedJavaType.getStringInstance()) // should be ignored
+
+        assertThat(toString(method)).isEqualTo("""
+                |public MyClass(String name) {
+                |    super(name);
+                |}
+                """.trimMargin())
+    }
+
+    @Test
+    fun testJavadocAndAnnotations() {
+        val method = Method("MyClass");
+        method.setVisibility(JavaVisibility.PUBLIC)
+        method.setConstructor(true)
+        method.addParameter(Parameter(FullyQualifiedJavaType.getStringInstance(), "name"))
+        method.addBodyLine("super(name);")
+
+        method.addAnnotation("@Generated")
+	method.addJavaDocLine("/**")
+	method.addJavaDocLine(" * Some Javadoc")
+	method.addJavaDocLine(" */")
+
+
+        assertThat(toString(method)).isEqualTo("""
+                |/**
+                | * Some Javadoc
+                | */
+                |@Generated
+                |public MyClass(String name) {
+                |    super(name);
+                |}
+                """.trimMargin())
+    }
+
+    private fun toString(m: Method, inInterface: Boolean = false) = MethodRenderer().render(m, inInterface, null)
+                .joinToString(System.getProperty("line.separator"))
+}

--- a/core/mybatis-generator-core/src/test/kotlin/org/mybatis/generator/api/dom/java/render/ParameterRendererTest.kt
+++ b/core/mybatis-generator-core/src/test/kotlin/org/mybatis/generator/api/dom/java/render/ParameterRendererTest.kt
@@ -1,0 +1,79 @@
+/**
+ *    Copyright 2006-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.generator.api.dom.java.render
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mybatis.generator.api.dom.java.FullyQualifiedJavaType
+import org.mybatis.generator.api.dom.java.Parameter
+import org.mybatis.generator.api.dom.java.TopLevelClass
+
+class ParameterRendererTest {
+    @Test
+    fun testBasicParameter() {
+        val renderer = ParameterRenderer();
+        val parameter = Parameter(FullyQualifiedJavaType.getStringInstance(), "firstName")
+
+        assertThat(renderer.render(parameter, null)).isEqualTo("String firstName")
+    }
+
+    @Test
+    fun testBasicParameterWithAnnotation() {
+        val renderer = ParameterRenderer();
+        val parameter = Parameter(FullyQualifiedJavaType.getStringInstance(), "firstName")
+        parameter.addAnnotation("""@Param("firstName")""")
+
+        assertThat(renderer.render(parameter, null)).isEqualTo("""@Param("firstName") String firstName""")
+    }
+	
+    @Test
+    fun testBasicVarargsParameter() {
+        val renderer = ParameterRenderer();
+        val parameter = Parameter(FullyQualifiedJavaType.getStringInstance(), "names", true)
+
+        assertThat(renderer.render(parameter, null)).isEqualTo("String ... names")
+    }
+
+    @Test
+    fun testParameterAndCuInSamePackage() {
+        val renderer = ParameterRenderer();
+        val cu = TopLevelClass("com.foo.Baz")
+        val parameter = Parameter(FullyQualifiedJavaType("com.foo.Bar"), "parm")
+
+        assertThat(renderer.render(parameter, cu)).isEqualTo("Bar parm")
+	
+    }
+
+    @Test
+    fun testParameterAndCuInSamePackageWithArguments() {
+        val renderer = ParameterRenderer();
+        val cu = TopLevelClass("com.foo.Baz")
+        val parameter = Parameter(FullyQualifiedJavaType("com.foo.Bar<java.lang.String>"), "parm")
+
+        assertThat(renderer.render(parameter, cu)).isEqualTo("Bar<String> parm")
+	
+    }
+
+    @Test
+    fun testParameterAndCuInDifferentPackage() {
+        val renderer = ParameterRenderer();
+        val cu = TopLevelClass("com.bar.Foo")
+        val parameter = Parameter(FullyQualifiedJavaType("com.foo.Bar"), "parm")
+
+        assertThat(renderer.render(parameter, cu)).isEqualTo("com.foo.Bar parm")
+	
+    }
+}

--- a/core/mybatis-generator-core/src/test/kotlin/org/mybatis/generator/api/dom/java/render/TypeParameterRendererTest.kt
+++ b/core/mybatis-generator-core/src/test/kotlin/org/mybatis/generator/api/dom/java/render/TypeParameterRendererTest.kt
@@ -1,0 +1,55 @@
+/**
+ *    Copyright 2006-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.generator.api.dom.java.render
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mybatis.generator.api.dom.java.FullyQualifiedJavaType
+import org.mybatis.generator.api.dom.java.TopLevelClass
+import org.mybatis.generator.api.dom.java.TypeParameter
+
+class TypeParameterRendererTest {
+    @Test
+    fun testSimpleTypeParameterRender() {
+        val renderer = TypeParameterRenderer()
+        val tp = TypeParameter("someName")
+
+        assertThat(renderer.render(tp, null)).isEqualTo("someName")
+    }
+
+    @Test
+    fun testComplexTypeParameterRenderNoCU() {
+        val renderer = TypeParameterRenderer()
+	val extendsTypes =listOf(FullyQualifiedJavaType("com.foo.Bar"))
+        val tp = TypeParameter("someName", extendsTypes)
+	
+        assertThat(renderer.render(tp, null)).isEqualTo("someName extends Bar")
+    }
+
+
+    @Test
+    fun testComplexTypeParameterRenderWithCU() {
+        val renderer = TypeParameterRenderer()
+	val tlc = TopLevelClass(FullyQualifiedJavaType("com.foo.Baz"))
+	tlc.addImportedType("com.bar.Foo2")
+	val extendsTypes =listOf(FullyQualifiedJavaType("java.lang.String"),
+	        FullyQualifiedJavaType("com.foo.Bar"), FullyQualifiedJavaType("com.bar.Foo"),
+	        FullyQualifiedJavaType("com.bar.Foo2"))
+        val tp = TypeParameter("someName", extendsTypes)
+	
+        assertThat(renderer.render(tp, tlc)).isEqualTo("someName extends String & Bar & com.bar.Foo & Foo2")
+    }
+}

--- a/core/mybatis-generator-core/src/test/kotlin/org/mybatis/generator/api/dom/xml/render/XmlRendererTest.kt
+++ b/core/mybatis-generator-core/src/test/kotlin/org/mybatis/generator/api/dom/xml/render/XmlRendererTest.kt
@@ -1,0 +1,175 @@
+/**
+ *    Copyright 2006-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.generator.api.dom.xml.render
+
+import org.assertj.core.api.Assertions.assertThat
+
+import org.junit.jupiter.api.Test
+import org.mybatis.generator.api.dom.DefaultXmlFormatter
+import org.mybatis.generator.api.dom.xml.Attribute
+import org.mybatis.generator.api.dom.xml.Document
+import org.mybatis.generator.api.dom.xml.TextElement
+import org.mybatis.generator.api.dom.xml.XmlElement
+
+class XmlRendererTest {
+
+    @Test
+    fun testNoDoctypeAndEmptyRoot() {
+        val doc = Document()
+        val root = XmlElement("root")
+        doc.setRootElement(root)
+
+        val expected = """
+                |<?xml version="1.0" encoding="UTF-8"?>
+                |<!DOCTYPE root>
+                |<root />""".trimMargin()
+
+        val formatter = DefaultXmlFormatter()
+        assertThat(formatter.getFormattedContent(doc)).isEqualTo(expected)
+    }
+
+    @Test
+    fun testSystemDoctypeAndEmptyRoot() {
+        val doc = Document("http://somedtd.com")
+        val root = XmlElement("root")
+        doc.setRootElement(root)
+
+        val expected = """
+                |<?xml version="1.0" encoding="UTF-8"?>
+                |<!DOCTYPE root SYSTEM "http://somedtd.com">
+                |<root />""".trimMargin()
+
+        val formatter = DefaultXmlFormatter()
+        assertThat(formatter.getFormattedContent(doc)).isEqualTo(expected)
+    }
+
+    @Test
+    fun testDoctypeAndEmptyRoot() {
+        val doc = Document("--/PublicId", "http://somedtd.com")
+        val root = XmlElement("root")
+        doc.setRootElement(root);
+
+        val expected = """
+                |<?xml version="1.0" encoding="UTF-8"?>
+                |<!DOCTYPE root PUBLIC "--/PublicId" "http://somedtd.com">
+                |<root />""".trimMargin()
+
+        val formatter = DefaultXmlFormatter()
+        assertThat(formatter.getFormattedContent(doc)).isEqualTo(expected)
+    }
+
+    @Test
+    fun testDoctypeAndRootWithAttribute() {
+        val doc = Document("--/PublicId", "http://somedtd.com")
+        val root = XmlElement("root")
+        root.addAttribute(Attribute("name", "fred"))
+        doc.setRootElement(root)
+
+        val expected = """
+                |<?xml version="1.0" encoding="UTF-8"?>
+                |<!DOCTYPE root PUBLIC "--/PublicId" "http://somedtd.com">
+                |<root name="fred" />""".trimMargin()
+
+        val formatter = DefaultXmlFormatter()
+        assertThat(formatter.getFormattedContent(doc)).isEqualTo(expected);
+    }
+
+    @Test
+    fun testDoctypeAndRootWithAttributes() {
+        val doc = Document("--/PublicId", "http://somedtd.com")
+        val root = XmlElement("root")
+        root.addAttribute(Attribute("firstName", "Fred"))
+        root.addAttribute(Attribute("lastName", "Flintstone"))
+        doc.setRootElement(root)
+
+        val expected = """
+                |<?xml version="1.0" encoding="UTF-8"?>
+                |<!DOCTYPE root PUBLIC "--/PublicId" "http://somedtd.com">
+                |<root firstName="Fred" lastName="Flintstone" />""".trimMargin()
+
+        val formatter = DefaultXmlFormatter()
+        assertThat(formatter.getFormattedContent(doc)).isEqualTo(expected);
+    }
+
+    @Test
+    fun testDoctypeAndRootWithTextChild() {
+        val doc = Document("--/PublicId", "http://somedtd.com")
+        val root = XmlElement("root")
+        root.addAttribute(Attribute("firstName", "Fred"))
+        root.addAttribute(Attribute("lastName", "Flintstone"))
+        
+        root.addElement(TextElement("some content"));
+        
+        doc.setRootElement(root);
+
+        val expected = """
+                |<?xml version="1.0" encoding="UTF-8"?>
+                |<!DOCTYPE root PUBLIC "--/PublicId" "http://somedtd.com">
+                |<root firstName="Fred" lastName="Flintstone">
+                |  some content
+                |</root>""".trimMargin();
+
+        val formatter = DefaultXmlFormatter()
+        assertThat(formatter.getFormattedContent(doc)).isEqualTo(expected);
+    }
+
+    @Test
+    fun testFullDocument() {
+        val doc = Document("--/PublicId", "http://somedtd.com")
+        val root = XmlElement("root")
+        root.addAttribute(Attribute("firstName", "Fred"))
+        root.addAttribute(Attribute("lastName", "Flintstone"))
+
+        root.addElement(TextElement("some content"));
+        
+        val child = XmlElement("child")
+        child.addAttribute(Attribute("firstName", "Pebbles"))
+        child.addAttribute(Attribute("lastName", "Flintstone"))
+        root.addElement(child)
+
+        val pet = XmlElement("pet")
+        val fn = XmlElement("firstName")
+        fn.addElement(TextElement("Dino"))
+        pet.addElement(fn)
+
+        val ln = XmlElement("lastName")
+        ln.addElement(TextElement("Flintstone"))
+        pet.addElement(ln)
+
+        root.addElement(pet)
+
+        doc.setRootElement(root);
+
+        val expected = """
+                |<?xml version="1.0" encoding="UTF-8"?>
+                |<!DOCTYPE root PUBLIC "--/PublicId" "http://somedtd.com">
+                |<root firstName="Fred" lastName="Flintstone">
+                |  some content
+                |  <child firstName="Pebbles" lastName="Flintstone" />
+                |  <pet>
+                |    <firstName>
+                |      Dino
+                |    </firstName>
+                |    <lastName>
+                |      Flintstone
+                |    </lastName>
+                |  </pet>
+                |</root>""".trimMargin();
+
+        val formatter = DefaultXmlFormatter()
+        assertThat(formatter.getFormattedContent(doc)).isEqualTo(expected);
+    }
+}

--- a/core/mybatis-generator-systests-domtests/src/main/java/mbg/domtest/GenerateTestSourceFiles.java
+++ b/core/mybatis-generator-systests-domtests/src/main/java/mbg/domtest/GenerateTestSourceFiles.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.StringTokenizer;
 
+import org.mybatis.generator.api.dom.DefaultJavaFormatter;
 import org.mybatis.generator.api.dom.java.CompilationUnit;
 import org.mybatis.generator.internal.util.StringUtility;
 import org.reflections.Reflections;
@@ -109,7 +110,8 @@ public class GenerateTestSourceFiles {
         String fileName = cu.getType().getShortName() + ".java";
         File targetFile = new File(directory, fileName);
 
-        writeFile(targetFile, cu.getFormattedContent());
+        DefaultJavaFormatter formatter = new DefaultJavaFormatter();
+        writeFile(targetFile, formatter.getFormattedContent(cu));
     }
 
     private void writeFile(File file, String content) throws IOException {

--- a/core/mybatis-generator-systests-mybatis3-java8/infinitest.filters
+++ b/core/mybatis-generator-systests-mybatis3-java8/infinitest.filters
@@ -1,0 +1,2 @@
+# exclude all tests as these are really integration tests and slow
+exclude .*Test

--- a/core/mybatis-generator-systests-mybatis3/infinitest.filters
+++ b/core/mybatis-generator-systests-mybatis3/infinitest.filters
@@ -1,0 +1,2 @@
+# exclude all tests as these are really integration tests and slow
+exclude .*Test

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -57,8 +57,9 @@
     <checkstyle.config>${project.basedir}/checkstyle-override.xml</checkstyle.config>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <junit.jupiter.version>5.3.0</junit.jupiter.version>
-    <junit.platform.version>1.3.0</junit.platform.version>
+    <kotlin.version>1.2.70</kotlin.version>
+    <junit.jupiter.version>5.3.1</junit.jupiter.version>
+    <junit.platform.version>1.3.1</junit.platform.version>
   </properties>
   
   <build>
@@ -96,6 +97,11 @@
               </tag>
             </tags>
           </configuration>
+        </plugin>
+        <plugin>
+          <artifactId>kotlin-maven-plugin</artifactId>
+          <groupId>org.jetbrains.kotlin</groupId>
+          <version>${kotlin.version}</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -258,13 +264,19 @@
       <dependency>
         <groupId>com.github.javaparser</groupId>
         <artifactId>javaparser-core</artifactId>
-        <version>3.6.20</version>
+        <version>3.6.22</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.mybatis.dynamic-sql</groupId>
         <artifactId>mybatis-dynamic-sql</artifactId>
         <version>1.1.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib</artifactId>
+        <version>${kotlin.version}</version>
+        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.reflections</groupId>

--- a/eclipse/org.mybatis.generator.eclipse.core.tests/infinitest.filters
+++ b/eclipse/org.mybatis.generator.eclipse.core.tests/infinitest.filters
@@ -1,0 +1,4 @@
+# exclude all tests as these are eclipse tests and can only run with the
+# eclipse JUnit plugin test runner
+exclude .*Test
+exclude .*Tests

--- a/eclipse/org.mybatis.generator.eclipse.tests.harness/infinitest.filters
+++ b/eclipse/org.mybatis.generator.eclipse.tests.harness/infinitest.filters
@@ -1,0 +1,3 @@
+# exclude all tests as these are eclipse tests and can only run with the
+# eclipse JUnit plugin test runner
+exclude .*Test


### PR DESCRIPTION
Improve the Java and XML DOM classes. The Java DOM is made more
consistent and has additional capabilities so that most types of Java
code are now supported including unlimited nesting of classes, enums,
and interfaces.

The XML DOM now supports both SYSTEM and PUBLIC doc types.

For both, the rendering of the DOM classes to a persistent format has
been delegated to new renderer classes that are more accurate and
consistent than the prior method.

There are a few backwards incompatible changes that are documented in
the "What's New" page. These should not cause any difficulty for most
users.

Finally, added Kotlin support for test classes!