### PR TITLE
Add an environment tab to the Eclipse launch configuration

### DIFF
--- a/eclipse/org.mybatis.generator.eclipse.doc/html-src/eclipseui/releasenotes.html
+++ b/eclipse/org.mybatis.generator.eclipse.doc/html-src/eclipseui/releasenotes.html
@@ -8,6 +8,12 @@
 </head>
 <body>
 <h1>MyBatis Generator Eclipse Feature Release Notes</h1>
+<h2>Version 1.4.0</h2>
+<ul>
+  <li>Added an environment tab to the launch configuration where properties can be set. Properties set on this tab will be available
+  for substitution into the generator configuration file.</li>
+</ul>
+
 <h2>Version 1.3.6</h2>
 <ul>
   <li>The popup menu item for running the generator is removed.  The generator can be run with a launcher,
@@ -27,7 +33,7 @@
 <h2>Version 1.3.4</h2>
 <p><b>Important Note:</b> After this release, we will remove the popup menu item for
 running the generator.  Please begin using the launch configuration support
-intead.</p>
+instead.</p>
 <ul>
   <li>Add a launch configuration to run the generator</li>
   <li>Add the generator DTDs to the XML catalog</li>

--- a/eclipse/org.mybatis.generator.eclipse.ui/antsrc/org/mybatis/generator/eclipse/ui/ant/GeneratorAntTask.java
+++ b/eclipse/org.mybatis.generator.eclipse.ui/antsrc/org/mybatis/generator/eclipse/ui/ant/GeneratorAntTask.java
@@ -118,7 +118,8 @@ public class GeneratorAntTask extends Task {
             subMonitor.beginTask("Generating MyBatis Artifacts:", 1000);
             subMonitor.subTask("Parsing Configuration");
             
-            Properties p = propertyset == null ? null : propertyset.getProperties();
+            Properties p = propertyset == null ? new Properties() : propertyset.getProperties();
+            p.putAll(getProject().getUserProperties());
             
             ConfigurationParser cp = new ConfigurationParser(p,
                     warnings);

--- a/eclipse/org.mybatis.generator.eclipse.ui/src/org/mybatis/generator/eclipse/ui/launcher/GeneratorLaunchConfigurationDelegate.java
+++ b/eclipse/org.mybatis.generator.eclipse.ui/src/org/mybatis/generator/eclipse/ui/launcher/GeneratorLaunchConfigurationDelegate.java
@@ -23,7 +23,11 @@ import java.io.OutputStreamWriter;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.eclipse.ant.core.AntCorePlugin;
 import org.eclipse.ant.core.AntCorePreferences;
@@ -75,6 +79,7 @@ public class GeneratorLaunchConfigurationDelegate extends AbstractJavaLaunchConf
             antRunner.setArguments("-debug"); //$NON-NLS-1$
         }
         
+        antRunner.addUserProperties(getUserProperties(configuration));
         antRunner.run(monitor);
         
         if (LauncherUtils.getBooleanOrFalse(configuration, GeneratorLaunchConstants.ATTR_SQL_SCRIPT_SECURE_CREDENTIALS)) {
@@ -83,6 +88,21 @@ public class GeneratorLaunchConfigurationDelegate extends AbstractJavaLaunchConf
         }
     }
     
+    private Map<String, String> getUserProperties(ILaunchConfiguration configuration) throws CoreException {
+        String[] env = getEnvironment(configuration);
+        if (env == null) {
+            return Collections.emptyMap();
+        }
+        
+        return Arrays.stream(env)
+                .map(this::parseProperty)
+                .collect(Collectors.toMap(sa -> sa[0], sa -> sa[1]));
+    }
+    
+    private String[] parseProperty(String in) {
+        return in.split("=", 2); //$NON-NLS-1$
+    }
+
     private void modifyAntClasspathIfNecessary(ILaunchConfiguration configuration, AntRunner antRunner) throws CoreException {
         String[] classpathEntries = getClasspath(configuration);
         if (classpathEntries == null || classpathEntries.length == 0) {

--- a/eclipse/org.mybatis.generator.eclipse.ui/src/org/mybatis/generator/eclipse/ui/launcher/GeneratorTabGroup.java
+++ b/eclipse/org.mybatis.generator.eclipse.ui/src/org/mybatis/generator/eclipse/ui/launcher/GeneratorTabGroup.java
@@ -17,6 +17,7 @@ package org.mybatis.generator.eclipse.ui.launcher;
 
 import org.eclipse.debug.ui.AbstractLaunchConfigurationTabGroup;
 import org.eclipse.debug.ui.CommonTab;
+import org.eclipse.debug.ui.EnvironmentTab;
 import org.eclipse.debug.ui.ILaunchConfigurationDialog;
 import org.eclipse.debug.ui.ILaunchConfigurationTab;
 import org.mybatis.generator.eclipse.ui.launcher.tabs.ConfigurationTab;
@@ -31,6 +32,7 @@ public class GeneratorTabGroup extends AbstractLaunchConfigurationTabGroup {
                 new ConfigurationTab(),
                 new SqlScriptTab(),
                 new UserClasspathTab(),
+                new EnvironmentTab(),
                 new CommonTab()
         };
         setTabs(tabs);


### PR DESCRIPTION
This allows properties to be set that can be substituted into a
generator configuration file.