### PR TITLE
[pom] Update junit to 5.3.2/1.3.2 & refactor how formatter would work

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -58,8 +58,8 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <kotlin.version>1.2.70</kotlin.version>
-    <junit.jupiter.version>5.3.1</junit.jupiter.version>
-    <junit.platform.version>1.3.1</junit.platform.version>
+    <junit.jupiter.version>5.3.2</junit.jupiter.version>
+    <junit.platform.version>1.3.2</junit.platform.version>
   </properties>
 
   <build>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -55,6 +55,7 @@
     <clirr.comparisonVersion>1.3.2</clirr.comparisonVersion>
     <hsqldb.version>2.4.1</hsqldb.version>
     <checkstyle.config>${project.basedir}/checkstyle-override.xml</checkstyle.config>
+    <formatter.config>eclipse-formatter-config-4space.xml</formatter.config>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <kotlin.version>1.2.70</kotlin.version>
@@ -315,33 +316,7 @@
         </pluginManagement>
       </build>
     </profile>
-    
-    <profile>
-      <id>format</id>
-      <activation>
-        <file>
-          <exists>format.xml</exists>
-        </file>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>net.revelc.code.formatter</groupId>
-            <artifactId>formatter-maven-plugin</artifactId>
-            <configuration>
-              <configFile>eclipse-formatter-config-4space.xml</configFile>
-            </configuration>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>format</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
+
     <profile>
      <id>eclipse</id>
       <activation>


### PR DESCRIPTION
* note - formatter was not enabled before and still is not.  To enable, it needs a 'format.xml' in each directory with a pom in order to start formatting.  This change is simply flipping this so that it uses much shorter setup if project is decided to enforce formatting rules.