### PR TITLE
javaClientGenerator增加skip参数，可以只是生成类，忽略方法

### DIFF
--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/IntrospectedTableMyBatis3Impl.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/IntrospectedTableMyBatis3Impl.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2006-2018 the original author or authors.
+ *    Copyright 2006-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import org.mybatis.generator.api.GeneratedXmlFile;
 import org.mybatis.generator.api.IntrospectedTable;
 import org.mybatis.generator.api.ProgressCallback;
 import org.mybatis.generator.api.dom.java.CompilationUnit;
+import org.mybatis.generator.api.dom.java.FullyQualifiedJavaType;
 import org.mybatis.generator.api.dom.xml.Document;
 import org.mybatis.generator.codegen.AbstractGenerator;
 import org.mybatis.generator.codegen.AbstractJavaClientGenerator;
@@ -179,6 +180,8 @@ public class IntrospectedTableMyBatis3Impl extends IntrospectedTable {
                                 javaGenerator.getProject(),
                                 context.getProperty(PropertyRegistry.CONTEXT_JAVA_FILE_ENCODING),
                                 context.getJavaFormatter());
+
+
                 answer.add(gjf);
             }
         }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/JavaMapperGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/JavaMapperGenerator.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2006-2018 the original author or authors.
+ *    Copyright 2006-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,11 +15,14 @@
  */
 package org.mybatis.generator.codegen.mybatis3.javamapper;
 
+import static org.mybatis.generator.internal.util.StringUtility.isTrue;
 import static org.mybatis.generator.internal.util.StringUtility.stringHasValue;
 import static org.mybatis.generator.internal.util.messages.Messages.getString;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 
 import org.mybatis.generator.api.CommentGenerator;
 import org.mybatis.generator.api.dom.java.CompilationUnit;
@@ -64,6 +67,7 @@ public class JavaMapperGenerator extends AbstractJavaClientGenerator {
 
         FullyQualifiedJavaType type = new FullyQualifiedJavaType(
                 introspectedTable.getMyBatis3JavaMapperType());
+
         Interface interfaze = new Interface(type);
         interfaze.setVisibility(JavaVisibility.PUBLIC);
         commentGenerator.addJavaFileComment(interfaze);
@@ -80,23 +84,40 @@ public class JavaMapperGenerator extends AbstractJavaClientGenerator {
                     rootInterface);
             interfaze.addSuperInterface(fqjt);
             interfaze.addImportedType(fqjt);
+
+            FullyQualifiedJavaType baseType = new FullyQualifiedJavaType(
+                    introspectedTable.getBaseRecordType());
+
+            FullyQualifiedJavaType fullyQualifiedJavaType = new FullyQualifiedJavaType(
+                    introspectedTable.getExampleType());
+
+
+            Set<FullyQualifiedJavaType> importedTypes = new TreeSet<>();
+            importedTypes.add(baseType);
+            importedTypes.add(fullyQualifiedJavaType);
+            interfaze.addImportedTypes(importedTypes);
         }
 
-        addCountByExampleMethod(interfaze);
-        addDeleteByExampleMethod(interfaze);
-        addDeleteByPrimaryKeyMethod(interfaze);
-        addInsertMethod(interfaze);
-        addInsertSelectiveMethod(interfaze);
-        addSelectByExampleWithBLOBsMethod(interfaze);
-        addSelectByExampleWithoutBLOBsMethod(interfaze);
-        addSelectByPrimaryKeyMethod(interfaze);
-        addUpdateByExampleSelectiveMethod(interfaze);
-        addUpdateByExampleWithBLOBsMethod(interfaze);
-        addUpdateByExampleWithoutBLOBsMethod(interfaze);
-        addUpdateByPrimaryKeySelectiveMethod(interfaze);
-        addUpdateByPrimaryKeyWithBLOBsMethod(interfaze);
-        addUpdateByPrimaryKeyWithoutBLOBsMethod(interfaze);
 
+        String skip = context.getJavaClientGeneratorConfiguration()
+                .getProperty(PropertyRegistry.SKIP);
+
+        if (!stringHasValue(skip) || !isTrue(skip)) {
+            addCountByExampleMethod(interfaze);
+            addDeleteByExampleMethod(interfaze);
+            addDeleteByPrimaryKeyMethod(interfaze);
+            addInsertMethod(interfaze);
+            addInsertSelectiveMethod(interfaze);
+            addSelectByExampleWithBLOBsMethod(interfaze);
+            addSelectByExampleWithoutBLOBsMethod(interfaze);
+            addSelectByPrimaryKeyMethod(interfaze);
+            addUpdateByExampleSelectiveMethod(interfaze);
+            addUpdateByExampleWithBLOBsMethod(interfaze);
+            addUpdateByExampleWithoutBLOBsMethod(interfaze);
+            addUpdateByPrimaryKeySelectiveMethod(interfaze);
+            addUpdateByPrimaryKeyWithBLOBsMethod(interfaze);
+            addUpdateByPrimaryKeyWithoutBLOBsMethod(interfaze);
+        }
         List<CompilationUnit> answer = new ArrayList<>();
         if (context.getPlugins().clientGenerated(interfaze, introspectedTable)) {
             answer.add(interfaze);

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/config/PropertyRegistry.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/config/PropertyRegistry.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2006-2018 the original author or authors.
+ *    Copyright 2006-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -19,9 +19,9 @@ package org.mybatis.generator.config;
  * This class holds constants for all properties recognized by the different
  * configuration elements. This helps document and maintain the different
  * properties, and helps to avoid spelling errors.
- * 
+ *
  * @author Jeff Butler
- * 
+ *
  */
 public class PropertyRegistry {
     public static final String ANY_ENABLE_SUB_PACKAGES = "enableSubPackages"; //$NON-NLS-1$
@@ -37,6 +37,7 @@ public class PropertyRegistry {
      * recognized by table and java client generator.
      */
     public static final String ANY_ROOT_INTERFACE = "rootInterface"; //$NON-NLS-1$
+    public static final String SKIP = "skip";
 
     public static final String TABLE_USE_COLUMN_INDEXES = "useColumnIndexes"; //$NON-NLS-1$
     public static final String TABLE_USE_ACTUAL_COLUMN_NAMES = "useActualColumnNames"; //$NON-NLS-1$
@@ -57,7 +58,7 @@ public class PropertyRegistry {
     public static final String CONTEXT_TARGET_JAVA8 = "targetJava8"; //$NON-NLS-1$
 
     public static final String CLIENT_USE_LEGACY_BUILDER = "useLegacyBuilder"; //$NON-NLS-1$
-    
+
     public static final String TYPE_RESOLVER_FORCE_BIG_DECIMALS = "forceBigDecimals"; //$NON-NLS-1$
     public static final String TYPE_RESOLVER_USE_JSR310_TYPES = "useJSR310Types"; //$NON-NLS-1$
 

--- a/core/mybatis-generator-core/src/site/xhtml/usage/mysql.xhtml
+++ b/core/mybatis-generator-core/src/site/xhtml/usage/mysql.xhtml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2006-2017 the original author or authors.
+       Copyright 2006-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.


### PR DESCRIPTION
javaClientGenerator增加skip参数，可以只是生成类，忽略方法，配合rootInterface使用可以生成只继承基类的DAO