### PR TITLE
Make MyBatisGenerator XML config to support nested property placeholders

### DIFF
--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/config/xml/MyBatisGeneratorConfigurationParser.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/config/xml/MyBatisGeneratorConfigurationParser.java
@@ -736,6 +736,11 @@ public class MyBatisGeneratorConfigurationParser {
             }
 
             int markerEndIndex = s.indexOf(CLOSE, currentIndex);
+            int nestedStartIndex = s.indexOf(OPEN, markerStartIndex + OPEN.length());
+            while (nestedStartIndex > -1 && markerEndIndex > -1 && nestedStartIndex < markerEndIndex) {
+	            nestedStartIndex = s.indexOf(OPEN, nestedStartIndex + OPEN.length());
+	            markerEndIndex = s.indexOf(CLOSE, markerEndIndex + CLOSE.length());
+            }
 
             if (markerEndIndex < 0) {
                 // no closing delimiter, just move to the end of the string
@@ -746,7 +751,7 @@ public class MyBatisGeneratorConfigurationParser {
 
             // we have a valid property marker...
             String property = s.substring(markerStartIndex + OPEN.length(), markerEndIndex);
-            String propertyValue = resolveProperty(property);
+            String propertyValue = resolveProperty(parsePropertyTokens(property));
             if (propertyValue == null) {
                 // add the property marker back into the stream
                 answer.add(s.substring(markerStartIndex, markerEndIndex + 1));

--- a/core/mybatis-generator-core/src/test/java/org/mybatis/generator/config/xml/PropertyParserTest.java
+++ b/core/mybatis-generator-core/src/test/java/org/mybatis/generator/config/xml/PropertyParserTest.java
@@ -137,4 +137,20 @@ public class PropertyParserTest {
         
         assertThat(result).isEqualTo("value1.value2.value3");
     }
+
+	@Test
+	public void testNestedValues() {
+		Properties properties = new Properties();
+		properties.put("domain", "foo");
+		properties.put("project.foo", "pfoo");
+		properties.put("addr", "localhost");
+		properties.put("env.localhost", "dev");
+		properties.put("jdbc.pfoo.dev.url", "mysql");
+
+		MyBatisGeneratorConfigurationParser parser = new MyBatisGeneratorConfigurationParser(properties);
+
+		String result = parser.parsePropertyTokens("${jdbc.${project.${domain}}.${env.${addr}}.url}");
+
+		assertThat(result).isEqualTo("mysql");
+	}
 }


### PR DESCRIPTION
MyBatis Generator Configuration XML nested property placeholders support.
For example:
driverClass="${jdbc.driver.${domain}}" connectionURL="${jdbc.url.${domain}}"