### PR TITLE
Don't clear JavaDoc when Building Model Classes for Dynamic SQL Runtime

### DIFF
--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/AbstractJavaGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/AbstractJavaGenerator.java
@@ -17,14 +17,11 @@ package org.mybatis.generator.codegen;
 
 import static org.mybatis.generator.internal.util.JavaBeansUtil.getGetterMethodName;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
-import java.util.Set;
 
 import org.mybatis.generator.api.dom.java.CompilationUnit;
 import org.mybatis.generator.api.dom.java.Field;
-import org.mybatis.generator.api.dom.java.FullyQualifiedJavaType;
 import org.mybatis.generator.api.dom.java.JavaVisibility;
 import org.mybatis.generator.api.dom.java.Method;
 import org.mybatis.generator.api.dom.java.TopLevelClass;
@@ -72,13 +69,17 @@ public abstract class AbstractJavaGenerator extends AbstractGenerator {
         topLevelClass.addMethod(getDefaultConstructor(topLevelClass));
     }
 
-    protected Method getDefaultConstructor(TopLevelClass topLevelClass) {
+    protected void addDefaultConstructorWithGeneratedAnnotatoin(TopLevelClass topLevelClass) {
+        topLevelClass.addMethod(getDefaultConstructorWithGeneratedAnnotation(topLevelClass));
+    }
+
+    private Method getDefaultConstructor(TopLevelClass topLevelClass) {
         Method method = getBasicConstructor(topLevelClass);
         addGeneratedJavaDoc(method);
         return method;
     }
 
-    protected Method getDefaultConstructorWithGeneratedAnnotation(TopLevelClass topLevelClass) {
+    private Method getDefaultConstructorWithGeneratedAnnotation(TopLevelClass topLevelClass) {
         Method method = getBasicConstructor(topLevelClass);
         addGeneratedAnnotation(method, topLevelClass);
         return method;

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/AbstractJavaGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/AbstractJavaGenerator.java
@@ -97,8 +97,7 @@ public abstract class AbstractJavaGenerator extends AbstractGenerator {
     }
 
     private void addGeneratedAnnotation(Method method, TopLevelClass topLevelClass) {
-        Set<FullyQualifiedJavaType> imports = new HashSet<>();
-        context.getCommentGenerator().addGeneralMethodAnnotation(method, introspectedTable, imports);
-        topLevelClass.addImportedTypes(imports);
+        context.getCommentGenerator().addGeneralMethodAnnotation(method, introspectedTable,
+                topLevelClass.getImportedTypes());
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/AbstractJavaGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/AbstractJavaGenerator.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2006-2018 the original author or authors.
+ *    Copyright 2006-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,11 +17,14 @@ package org.mybatis.generator.codegen;
 
 import static org.mybatis.generator.internal.util.JavaBeansUtil.getGetterMethodName;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
+import java.util.Set;
 
 import org.mybatis.generator.api.dom.java.CompilationUnit;
 import org.mybatis.generator.api.dom.java.Field;
+import org.mybatis.generator.api.dom.java.FullyQualifiedJavaType;
 import org.mybatis.generator.api.dom.java.JavaVisibility;
 import org.mybatis.generator.api.dom.java.Method;
 import org.mybatis.generator.api.dom.java.TopLevelClass;
@@ -70,11 +73,32 @@ public abstract class AbstractJavaGenerator extends AbstractGenerator {
     }
 
     protected Method getDefaultConstructor(TopLevelClass topLevelClass) {
+        Method method = getBasicConstructor(topLevelClass);
+        addGeneratedJavaDoc(method);
+        return method;
+    }
+
+    protected Method getDefaultConstructorWithGeneratedAnnotation(TopLevelClass topLevelClass) {
+        Method method = getBasicConstructor(topLevelClass);
+        addGeneratedAnnotation(method, topLevelClass);
+        return method;
+    }
+
+    private Method getBasicConstructor(TopLevelClass topLevelClass) {
         Method method = new Method(topLevelClass.getType().getShortName());
         method.setVisibility(JavaVisibility.PUBLIC);
         method.setConstructor(true);
         method.addBodyLine("super();"); //$NON-NLS-1$
-        context.getCommentGenerator().addGeneralMethodComment(method, introspectedTable);
         return method;
+    }
+    
+    private void addGeneratedJavaDoc(Method method) {
+        context.getCommentGenerator().addGeneralMethodComment(method, introspectedTable);
+    }
+
+    private void addGeneratedAnnotation(Method method, TopLevelClass topLevelClass) {
+        Set<FullyQualifiedJavaType> imports = new HashSet<>();
+        context.getCommentGenerator().addGeneralMethodAnnotation(method, introspectedTable, imports);
+        topLevelClass.addImportedTypes(imports);
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/internal/util/JavaBeansUtil.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/internal/util/JavaBeansUtil.java
@@ -22,6 +22,7 @@ import java.util.Properties;
 
 import org.mybatis.generator.api.IntrospectedColumn;
 import org.mybatis.generator.api.IntrospectedTable;
+import org.mybatis.generator.api.dom.java.CompilationUnit;
 import org.mybatis.generator.api.dom.java.Field;
 import org.mybatis.generator.api.dom.java.FullyQualifiedJavaType;
 import org.mybatis.generator.api.dom.java.JavaVisibility;
@@ -189,6 +190,21 @@ public class JavaBeansUtil {
     public static Method getJavaBeansGetter(IntrospectedColumn introspectedColumn,
             Context context,
             IntrospectedTable introspectedTable) {
+        Method method = getBasicJavaBeansGetter(introspectedColumn, context, introspectedTable);
+        addGeneratedGetterJavaDoc(method, introspectedColumn, context, introspectedTable);
+        return method;
+    }
+
+    public static Method getJavaBeansGetterWithGeneratedAnnotation(IntrospectedColumn introspectedColumn,
+            Context context, IntrospectedTable introspectedTable, CompilationUnit compilationUnit) {
+        Method method = getBasicJavaBeansGetter(introspectedColumn, context, introspectedTable);
+        addGeneratedGetterAnnotation(method, introspectedColumn, context, introspectedTable, compilationUnit);
+        return method;
+    }
+
+    private static Method getBasicJavaBeansGetter(IntrospectedColumn introspectedColumn,
+            Context context,
+            IntrospectedTable introspectedTable) {
         FullyQualifiedJavaType fqjt = introspectedColumn
                 .getFullyQualifiedJavaType();
         String property = introspectedColumn.getJavaProperty();
@@ -196,8 +212,6 @@ public class JavaBeansUtil {
         Method method = new Method(getGetterMethodName(property, fqjt));
         method.setVisibility(JavaVisibility.PUBLIC);
         method.setReturnType(fqjt);
-        context.getCommentGenerator().addGetterComment(method,
-                introspectedTable, introspectedColumn);
 
         StringBuilder sb = new StringBuilder();
         sb.append("return "); //$NON-NLS-1$
@@ -207,25 +221,75 @@ public class JavaBeansUtil {
 
         return method;
     }
+    
+    private static void addGeneratedGetterJavaDoc(Method method, IntrospectedColumn introspectedColumn, Context context, IntrospectedTable introspectedTable) {
+        context.getCommentGenerator().addGetterComment(method,
+                introspectedTable, introspectedColumn);
+    }
+
+    private static void addGeneratedGetterAnnotation(Method method, IntrospectedColumn introspectedColumn, Context context,
+            IntrospectedTable introspectedTable, CompilationUnit compilationUnit) {
+        context.getCommentGenerator().addGeneralMethodAnnotation(method, introspectedTable, introspectedColumn,
+                compilationUnit.getImportedTypes());
+    }
 
     public static Field getJavaBeansField(IntrospectedColumn introspectedColumn,
             Context context,
             IntrospectedTable introspectedTable) {
+        Field field = getBasicJavaBeansField(introspectedColumn);
+        addGeneratedJavaDoc(field, context, introspectedColumn, introspectedTable);
+        return field;
+    }
+
+    public static Field getJavaBeansFieldWithGeneratedAnnotation(IntrospectedColumn introspectedColumn,
+            Context context,
+            IntrospectedTable introspectedTable,
+            CompilationUnit compilationUnit) {
+        Field field = getBasicJavaBeansField(introspectedColumn);
+        addGeneratedAnnotation(field, context, introspectedColumn, introspectedTable, compilationUnit);
+        return field;
+    }
+
+    private static Field getBasicJavaBeansField(IntrospectedColumn introspectedColumn) {
         FullyQualifiedJavaType fqjt = introspectedColumn
                 .getFullyQualifiedJavaType();
         String property = introspectedColumn.getJavaProperty();
 
         Field field = new Field(property, fqjt);
         field.setVisibility(JavaVisibility.PRIVATE);
-        context.getCommentGenerator().addFieldComment(field,
-                introspectedTable, introspectedColumn);
 
         return field;
     }
+    
+    private static void addGeneratedJavaDoc(Field field, Context context, IntrospectedColumn introspectedColumn,
+            IntrospectedTable introspectedTable) {
+        context.getCommentGenerator().addFieldComment(field,
+                introspectedTable, introspectedColumn);
+    }
 
+    private static void addGeneratedAnnotation(Field field, Context context, IntrospectedColumn introspectedColumn,
+            IntrospectedTable introspectedTable, CompilationUnit compilationUnit) {
+        context.getCommentGenerator().addFieldAnnotation(field, introspectedTable, introspectedColumn,
+                compilationUnit.getImportedTypes());
+    }
+    
     public static Method getJavaBeansSetter(IntrospectedColumn introspectedColumn,
             Context context,
             IntrospectedTable introspectedTable) {
+        Method method = getBasicJavaBeansSetter(introspectedColumn);
+        addGeneratedSetterJavaDoc(method, introspectedColumn, context, introspectedTable);
+        return method;
+    }
+
+    public static Method getJavaBeansSetterWithGeneratedAnnotation(IntrospectedColumn introspectedColumn,
+            Context context,
+            IntrospectedTable introspectedTable, CompilationUnit compilationUnit) {
+        Method method = getBasicJavaBeansSetter(introspectedColumn);
+        addGeneratedSetterAnnotation(method, introspectedColumn, context, introspectedTable, compilationUnit);
+        return method;
+    }
+
+    private static Method getBasicJavaBeansSetter(IntrospectedColumn introspectedColumn) {
         FullyQualifiedJavaType fqjt = introspectedColumn
                 .getFullyQualifiedJavaType();
         String property = introspectedColumn.getJavaProperty();
@@ -233,8 +297,6 @@ public class JavaBeansUtil {
         Method method = new Method(getSetterMethodName(property));
         method.setVisibility(JavaVisibility.PUBLIC);
         method.addParameter(new Parameter(fqjt, property));
-        context.getCommentGenerator().addSetterComment(method,
-                introspectedTable, introspectedColumn);
 
         StringBuilder sb = new StringBuilder();
         if (introspectedColumn.isStringColumn() && isTrimStringsEnabled(introspectedColumn)) {
@@ -257,7 +319,19 @@ public class JavaBeansUtil {
 
         return method;
     }
+    
+    private static void addGeneratedSetterJavaDoc(Method method, IntrospectedColumn introspectedColumn, Context context,
+            IntrospectedTable introspectedTable) {
+        context.getCommentGenerator().addSetterComment(method,
+                introspectedTable, introspectedColumn);
+    }
 
+    private static void addGeneratedSetterAnnotation(Method method, IntrospectedColumn introspectedColumn, Context context,
+            IntrospectedTable introspectedTable, CompilationUnit compilationUnit) {
+        context.getCommentGenerator().addGeneralMethodAnnotation(method, introspectedTable, introspectedColumn,
+                compilationUnit.getImportedTypes());
+    }
+    
     private static boolean isTrimStringsEnabled(Context context) {
         Properties properties = context
                 .getJavaModelGeneratorConfiguration().getProperties();

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/DynamicSqlModelGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/DynamicSqlModelGenerator.java
@@ -75,8 +75,7 @@ public class DynamicSqlModelGenerator extends AbstractJavaGenerator {
             addParameterizedConstructor(topLevelClass);
 
             if (!introspectedTable.isImmutable()) {
-                Method method = getDefaultConstructorWithGeneratedAnnotation(topLevelClass);
-                topLevelClass.addMethod(method);
+                addDefaultConstructorWithGeneratedAnnotatoin(topLevelClass);
             }
         }
 

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/DynamicSqlModelGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/DynamicSqlModelGenerator.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2006-2018 the original author or authors.
+ *    Copyright 2006-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,9 +15,7 @@
  */
 package org.mybatis.generator.runtime.dynamic.sql;
 
-import static org.mybatis.generator.internal.util.JavaBeansUtil.getJavaBeansField;
-import static org.mybatis.generator.internal.util.JavaBeansUtil.getJavaBeansGetter;
-import static org.mybatis.generator.internal.util.JavaBeansUtil.getJavaBeansSetter;
+import static org.mybatis.generator.internal.util.JavaBeansUtil.*;
 import static org.mybatis.generator.internal.util.messages.Messages.getString;
 
 import java.util.ArrayList;
@@ -74,12 +72,10 @@ public class DynamicSqlModelGenerator extends AbstractJavaGenerator {
         List<IntrospectedColumn> introspectedColumns = introspectedTable.getAllColumns();
 
         if (introspectedTable.isConstructorBased()) {
-            addParameterizedConstructor(topLevelClass, commentGenerator);
+            addParameterizedConstructor(topLevelClass);
 
             if (!introspectedTable.isImmutable()) {
-                Method method = getDefaultConstructor(topLevelClass);
-                method.getJavaDocLines().clear();
-                commentGenerator.addGeneralMethodAnnotation(method, introspectedTable, topLevelClass.getImportedTypes());
+                Method method = getDefaultConstructorWithGeneratedAnnotation(topLevelClass);
                 topLevelClass.addMethod(method);
             }
         }
@@ -91,9 +87,9 @@ public class DynamicSqlModelGenerator extends AbstractJavaGenerator {
                 continue;
             }
 
-            Field field = getJavaBeansField(introspectedColumn, context, introspectedTable);
-            field.getJavaDocLines().clear();
-            commentGenerator.addFieldAnnotation(field, introspectedTable, introspectedColumn, topLevelClass.getImportedTypes());
+            Field field = getJavaBeansFieldWithGeneratedAnnotation(introspectedColumn, context, introspectedTable,
+                    topLevelClass);
+            
             if (plugins.modelFieldGenerated(field, topLevelClass,
                     introspectedColumn, introspectedTable,
                     Plugin.ModelClassType.BASE_RECORD)) {
@@ -101,9 +97,8 @@ public class DynamicSqlModelGenerator extends AbstractJavaGenerator {
                 topLevelClass.addImportedType(field.getType());
             }
 
-            Method method = getJavaBeansGetter(introspectedColumn, context, introspectedTable);
-            method.getJavaDocLines().clear();
-            commentGenerator.addGeneralMethodAnnotation(method, introspectedTable, introspectedColumn, topLevelClass.getImportedTypes());
+            Method method = getJavaBeansGetterWithGeneratedAnnotation(introspectedColumn, context, introspectedTable,
+                    topLevelClass);
             if (plugins.modelGetterMethodGenerated(method, topLevelClass,
                     introspectedColumn, introspectedTable,
                     Plugin.ModelClassType.BASE_RECORD)) {
@@ -111,9 +106,8 @@ public class DynamicSqlModelGenerator extends AbstractJavaGenerator {
             }
 
             if (!introspectedTable.isImmutable()) {
-                method = getJavaBeansSetter(introspectedColumn, context, introspectedTable);
-                method.getJavaDocLines().clear();
-                commentGenerator.addGeneralMethodAnnotation(method, introspectedTable, introspectedColumn, topLevelClass.getImportedTypes());
+                method = getJavaBeansSetterWithGeneratedAnnotation(introspectedColumn, context, introspectedTable,
+                        topLevelClass);
                 if (plugins.modelSetterMethodGenerated(method, topLevelClass,
                         introspectedColumn, introspectedTable,
                         Plugin.ModelClassType.BASE_RECORD)) {
@@ -142,14 +136,11 @@ public class DynamicSqlModelGenerator extends AbstractJavaGenerator {
         return superClass;
     }
 
-    private void addParameterizedConstructor(TopLevelClass topLevelClass, CommentGenerator commentGenerator) {
+    private void addParameterizedConstructor(TopLevelClass topLevelClass) {
         Method method = new Method(topLevelClass.getType().getShortName());
         method.setVisibility(JavaVisibility.PUBLIC);
         method.setConstructor(true);
-        context.getCommentGenerator().addGeneralMethodComment(method,
-                introspectedTable);
-        method.getJavaDocLines().clear();
-        commentGenerator.addGeneralMethodAnnotation(method, introspectedTable, topLevelClass.getImportedTypes());
+        context.getCommentGenerator().addGeneralMethodAnnotation(method, introspectedTable, topLevelClass.getImportedTypes());
 
         List<IntrospectedColumn> constructorColumns = introspectedTable
                 .getAllColumns();


### PR DESCRIPTION
Fixes #463 
