### PR TITLE
Fix for classPath found problem when multi module project use profile…

### DIFF
--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/internal/util/ClassloaderUtility.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/internal/util/ClassloaderUtility.java
@@ -51,7 +51,7 @@ public class ClassloaderUtility {
             for (String classPathEntry : entries) {
                 file = new File(classPathEntry);
                 if (!file.exists()) {
-                    LOG.warn("classPathEntry " + classPathEntry + " not exists!" );
+                    LOG.warn(getString("Warning.31", classPathEntry));
                     continue;
                 }
 

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/internal/util/ClassloaderUtility.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/internal/util/ClassloaderUtility.java
@@ -15,6 +15,9 @@
  */
 package org.mybatis.generator.internal.util;
 
+import org.mybatis.generator.logging.Log;
+import org.mybatis.generator.logging.LogFactory;
+
 import static org.mybatis.generator.internal.util.messages.Messages.getString;
 
 import java.io.File;
@@ -33,6 +36,7 @@ import java.util.List;
  */
 public class ClassloaderUtility {
 
+    private static final Log LOG = LogFactory.getLog(ClassloaderUtility.class);
     /**
      * Utility Class - No Instances.
      */
@@ -47,8 +51,8 @@ public class ClassloaderUtility {
             for (String classPathEntry : entries) {
                 file = new File(classPathEntry);
                 if (!file.exists()) {
-                    throw new RuntimeException(getString(
-                            "RuntimeError.9", classPathEntry)); //$NON-NLS-1$
+                    LOG.warn("classPathEntry " + classPathEntry + " not exists!" );
+                    continue;
                 }
 
                 try {

--- a/core/mybatis-generator-core/src/main/resources/org/mybatis/generator/internal/util/messages/messages.properties
+++ b/core/mybatis-generator-core/src/main/resources/org/mybatis/generator/internal/util/messages/messages.properties
@@ -97,6 +97,7 @@ Warning.27=Exception retrieving table metadata: {0}
 Warning.28=Property {0} exists in root class {1}, but type cannot be determined because the root class is generic.  MyBatis Generator will assume the type matches.
 Warning.29=Shortcut field for SQLColumn "{0}" skipped in class {1} due to name collision 
 Warning.30=The RowBoundsPlugin is not valid for MyBatis3DynamicSqlV2. Use the built-in limit/offset support instead.
+Warning.31=ClassPathEntry {0} not exists.
 
 Progress.0=Connecting to the Database
 Progress.1=Introspecting table {0}


### PR DESCRIPTION
Fix for classPath found problem when multi module project use profile

When parent pom has been setting

```xml
<profiles>
  <profile>
    <id>dev</id>
    <build>
      <resources>
        <resource>
          <directory>src/main/profiles/dev</directory>
        </resource>
        <resource>
          <directory>src/main/resources</directory>
        </resource>
      </resources>
    </build>
  </profile>
</profiles>
```
 generator will find classpath under src/main/profiles/dev. But in sub modules, there is no such path. So we need to warn this, not throw an exception.