### PR TITLE
make <dateFormat> effective on GeneratedAnnotation and kotlinFile comment

### DIFF
--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/internal/DefaultCommentGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/internal/DefaultCommentGenerator.java
@@ -465,7 +465,7 @@ public class DefaultCommentGenerator implements CommentGenerator {
 
         if (!suppressDate && !suppressAllComments) {
             buffer.append(", date=\""); //$NON-NLS-1$
-            buffer.append(DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(ZonedDateTime.now()));
+            buffer.append(getDateString());
             buffer.append('\"');
         }
 
@@ -489,7 +489,7 @@ public class DefaultCommentGenerator implements CommentGenerator {
         kotlinFile.addFileCommentLine(" * Auto-generated file. Created by MyBatis Generator"); //$NON-NLS-1$
         if (!suppressDate) {
             kotlinFile.addFileCommentLine(" * Generation date: " //$NON-NLS-1$
-                    + DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(ZonedDateTime.now()));
+                    + getDateString());
         }
         kotlinFile.addFileCommentLine(" */"); //$NON-NLS-1$
     }


### PR DESCRIPTION
the <dateFormat> element of comment generator in MBG configuration file works well in most cases, but takes no effect on GeneratedAnnotation and kotlinFile comment. With a little modification, it will take effect.