### PR TITLE
move serialVersionUID to first field

### DIFF
--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/plugins/SerializablePlugin.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/plugins/SerializablePlugin.java
@@ -111,7 +111,8 @@ public class SerializablePlugin extends PluginAdapter {
                 context.getCommentGenerator().addFieldComment(field, introspectedTable);
             }
 
-            topLevelClass.addField(field);
+            // serialVersionUID field should be the first field of java model
+            topLevelClass.getFields().add(0, field);
         }
     }
 }


### PR DESCRIPTION
generally serialVersionUID is the first field of java model, ex.

public class Person implements Serializable {
    private static final long serialVersionUID = 1L;
...
...