### PR TITLE
Setup Sonar for the Generator

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -18,7 +18,7 @@ name: SonarCloud
 
 defaults:
   run:
-    working-directory: core
+    working-directory: core/mybatis-generator-core
 
 on:
   push:
@@ -39,7 +39,7 @@ jobs:
         with:
           java-version: 11
       - name: Analyze with SonarCloud
-        run: ./mvnw verify sonar:sonar -B -Dsonar.projectKey=mybatis_generator -Dsonar.organization=mybatis -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN -Dlicense.skip=true
+        run: ../mvnw verify jacoco:report sonar:sonar -B -Dsonar.projectKey=mybatis_generator -Dsonar.organization=mybatis -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONAR_TOKEN -Dlicense.skip=true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
We need to run jacoco:report to get code coverage into sonar. Also,
only run sonar analysis on the main project.