### PR TITLE
Add Property to Force Java Type into Generated Mappings

### DIFF
--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/MyBatisGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/MyBatisGenerator.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
+import java.nio.charset.Charset;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -427,7 +428,7 @@ public class MyBatisGenerator {
             if (fileEncoding == null) {
                 osw = new OutputStreamWriter(fos);
             } else {
-                osw = new OutputStreamWriter(fos, fileEncoding);
+                osw = new OutputStreamWriter(fos, Charset.forName(fileEncoding));
             }
 
             try (BufferedWriter bw = new BufferedWriter(osw)) {

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/config/PropertyRegistry.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/config/PropertyRegistry.java
@@ -74,4 +74,6 @@ public class PropertyRegistry {
     public static final String COMMENT_GENERATOR_SUPPRESS_ALL_COMMENTS = "suppressAllComments"; //$NON-NLS-1$
     public static final String COMMENT_GENERATOR_ADD_REMARK_COMMENTS = "addRemarkComments"; //$NON-NLS-1$
     public static final String COMMENT_GENERATOR_DATE_FORMAT = "dateFormat"; //$NON-NLS-1$
+
+    public static final String COLUMN_OVERRIDE_FORCE_JAVA_TYPE = "forceJavaTypeIntoMapping"; //$NON-NLS-1$
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/kotlin/KotlinDynamicSqlSupportClassGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/kotlin/KotlinDynamicSqlSupportClassGenerator.java
@@ -30,6 +30,7 @@ import org.mybatis.generator.api.dom.kotlin.KotlinFile;
 import org.mybatis.generator.api.dom.kotlin.KotlinProperty;
 import org.mybatis.generator.api.dom.kotlin.KotlinType;
 import org.mybatis.generator.config.Context;
+import org.mybatis.generator.config.PropertyRegistry;
 import org.mybatis.generator.internal.util.JavaBeansUtil;
 import org.mybatis.generator.internal.util.StringUtility;
 import org.mybatis.generator.internal.util.messages.Messages;
@@ -181,10 +182,16 @@ public class KotlinDynamicSqlSupportClassGenerator {
 
         if (StringUtility.stringHasValue(column.getTypeHandler())) {
             initializationString.append(
-                    String.format(", typeHandler = \"%s\")", column.getTypeHandler())); //$NON-NLS-1$
-        } else {
-            initializationString.append(')');
+                    String.format(", typeHandler = \"%s\"", column.getTypeHandler())); //$NON-NLS-1$
         }
+
+        if (StringUtility.isTrue(
+                column.getProperties().getProperty(PropertyRegistry.COLUMN_OVERRIDE_FORCE_JAVA_TYPE))) {
+            initializationString.append(
+                    String.format(", javaType = %s::class", kt.getShortNameWithoutTypeArguments())); //$NON-NLS-1$
+        }
+
+        initializationString.append(')'); //$NON-NLS-1$
 
         return initializationString.toString();
     }

--- a/core/mybatis-generator-core/src/site/xhtml/configreference/columnOverride.xhtml
+++ b/core/mybatis-generator-core/src/site/xhtml/configreference/columnOverride.xhtml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2006-2018 the original author or authors.
+       Copyright 2006-2022 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -132,21 +132,32 @@ specified with the <a href="property.html">&lt;property&gt;</a> child element:</
     <th>Property Values</th>
   </tr>
   <tr>
-    <td valign="top">trimStrings</td>
+    <td valign="top">forceJavaTypeIntoMapping</td>
     <td>
-      This property is used to select whether MyBatis Generator adds code to trim
-      the white space from character fields returned from the database.
-      This can be useful if your database stores data in CHAR fields rather than
-      VARCHAR fields.  When true for a character field/column, MyBatis Generator will 
-      insert code to trim leading and trailing whitespace.
-      This property value overrides the property if specified at the 
-      <a href="table.html">&lt;javaModelGenerator&gt;</a> and/or 
-      <a href="javaModelGenerator.html">&lt;table&gt;</a> level.
-      
-      <p><i>The default value is inherited from the 
-      <a href="table.html">&lt;javaModelGenerator&gt;</a> and/or 
-      <a href="javaModelGenerator.html">&lt;javaModelGenerator&gt;</a>, otherwise false.</i></p></td>
+      When true, this property will add the Java type to the generated mappings. This is normally not necessary.
+      However some functions will need it such as when you use MyBatis' EnumOrdinalTypeHandler.
+
+      <p>This property is only recognized, and only needed, by the MyBatis3DynamicSQL and MyBatis3Kotlin runtimes.</p>
+      <p><i>The default value is false</i></p>
+      <p>Since version 1.4.1</p>
+    </td>
   </tr>
+    <tr>
+        <td valign="top">trimStrings</td>
+        <td>
+            This property is used to select whether MyBatis Generator adds code to trim
+            the white space from character fields returned from the database.
+            This can be useful if your database stores data in CHAR fields rather than
+            VARCHAR fields.  When true for a character field/column, MyBatis Generator will
+            insert code to trim leading and trailing whitespace.
+            This property value overrides the property if specified at the
+            <a href="table.html">&lt;javaModelGenerator&gt;</a> and/or
+            <a href="javaModelGenerator.html">&lt;table&gt;</a> level.
+
+            <p><i>The default value is inherited from the
+                <a href="table.html">&lt;javaModelGenerator&gt;</a> and/or
+                <a href="javaModelGenerator.html">&lt;javaModelGenerator&gt;</a>, otherwise false.</i></p></td>
+    </tr>
 </table>
 </body>
 </html>

--- a/core/mybatis-generator-core/src/site/xhtml/whatsNew.xhtml
+++ b/core/mybatis-generator-core/src/site/xhtml/whatsNew.xhtml
@@ -27,9 +27,10 @@
 <h1>What's New in MyBatis Generator</h1>
 <h2>Version 1.4.1</h2>
 <p>This release is primarily focused on updating the runtimes for MyBatis Dynamic SQL ("MyBatis3DynamicSQL" and
-"MyBatis3Kotlin"). The generated Java code is now dependent on MyBatis Dynamic SQL version 1.3.1 or later. The
-generated Kotlin code is now dependent on MyBatis Dynamic SQL version 1.4.0 or later. See below for details about these
-changes. See the GitHub page for milestone 1.4.1 for details other changes in this release:
+"MyBatis3Kotlin"). The generated code for "MyBatis3DynamicSQL" is now dependent on MyBatis Dynamic SQL version 1.3.1 or
+later. The generated code for "MyBatis3Kotlin" is now dependent on MyBatis Dynamic SQL version 1.4.0 or later. See
+below for details about these changes. See the GitHub page for milestone 1.4.1 for details other changes in this
+release:
 <a target="_blank" href="https://github.com/mybatis/generator/issues?q=milestone%3A1.4.1">Milestone 1.4.1</a>.</p>
 
 <h3>Updated MyBatis Dynamic SQL Runtimes</h3>
@@ -83,15 +84,16 @@ reference. For example, if you have a table named "Bar", you may see code like t
     val bar = Bar(1, 2)      // remove "Record"
 </pre>
 
-<p>Additionally, generated support classes now declare an instance of the <code>SqlTable</code> object, and all fields,
-as values in the top level object. If you wrote custom code that used these generated objects, two changes will be
-required:</p>
+<p>Additionally, generated support classes now declare an instance of the <code>AliasableSqlTable</code> object,
+and all fields, as values in the top level object. If you wrote custom code that used these generated objects, two
+changes will be required:</p>
 
 <ul>
-    <li>The declared <code>SqlTable</code> object is now an instance of an inner Class rather than an inner Object.
-        It should be referenced with the new name (typically the same name as previously, with the first letter now
-        lowercase)</li>
-    <li>References to any <code>SqlColumn</code> should reference the top level value rather than a nested value</li>
+    <li>The declared <code>AliasableSqlTable</code> object is now an instance of an inner Class rather than an inner
+        Object. It should be referenced with the new name (typically the same name as previously, with the first letter
+        now lowercase)</li>
+    <li>References to any <code>AliasableSqlColumn</code> should reference the top level value rather than a nested
+        value</li>
 </ul>
 
 <p>For example, previously code might have looked like this:</p>
@@ -116,9 +118,9 @@ required:</p>
     }
 </pre>
 
-<p>Lastly, the generated code uses upgraded DSL features that should be mostly transparent. But you will notice that any
-    "where" clauses you write will likely have deprecation warnings. This is due to a change in MyBatis Dynamic SQL. You
-    can read about remediation of these warnings in the documentation for that project.
+<p>Lastly, the generated Kotlin code uses upgraded DSL features that should be mostly transparent. But you will notice
+    that any "where" clauses you write will likely have deprecation warnings. This is due to a change in MyBatis
+    Dynamic SQL. You can read about remediation of these warnings in the documentation for that project.
 </p>
 
 <h3>Other Enhancements</h3>
@@ -129,6 +131,10 @@ required:</p>
     <li>Added a plugin to generate @CacheNamespace annotations</li>
     <li>Added the ability to specify a name for the inner class generated in the MyBatis Dynamic SQL support class</li>
     <li>Added plugin methods that allow generation of any arbitrary file type</li>
+    <li>Added a property to &lt;columnOverride&gt; that forces the Java type into generated mappings for the
+        MyBatis Dynamic SQL based runtimes. This is useful in certain cases such as when you use MyBatis'
+        EnumOrdinalTypeHandler.
+    </li>
 </ul>
 
 <h3>Removed Items</h3>

--- a/core/mybatis-generator-core/src/test/resources/scripts/CreateDB.sql
+++ b/core/mybatis-generator-core/src/test/resources/scripts/CreateDB.sql
@@ -1,5 +1,5 @@
 --
---    Copyright 2006-2018 the original author or authors.
+--    Copyright 2006-2022 the original author or authors.
 --
 --    Licensed under the Apache License, Version 2.0 (the "License");
 --    you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ drop table mbgtest.Translations if exists;
 drop table CompoundKey if exists;
 drop schema mbgtest if exists;
 drop table EnumTest if exists;
+drop table EnumOrdinalTest if exists;
 drop table GeneratedAlwaysTest if exists;
 drop table GeneratedAlwaysTestNoUpdates if exists;
 drop table IgnoreManyColumns if exists;
@@ -152,6 +153,12 @@ create table CompoundKey (
 create table EnumTest (
   id int not null,
   name varchar(20) not null,
+  primary key(id)
+);
+
+create table EnumOrdinalTest (
+  id int not null,
+  enumOrdinal int not null,
   primary key(id)
 );
 

--- a/core/mybatis-generator-core/src/test/resources/scripts/CreateDB.sql
+++ b/core/mybatis-generator-core/src/test/resources/scripts/CreateDB.sql
@@ -158,7 +158,7 @@ create table EnumTest (
 
 create table EnumOrdinalTest (
   id int not null,
-  enumOrdinal int not null,
+  name int not null,
   primary key(id)
 );
 

--- a/core/mybatis-generator-core/src/test/resources/scripts/generatorConfig-kotlin.xml
+++ b/core/mybatis-generator-core/src/test/resources/scripts/generatorConfig-kotlin.xml
@@ -160,7 +160,9 @@
     </table>
     <table tableName="EnumOrdinalTest">
       <columnOverride column="name" javaType="mbg.test.mb3.common.TestEnum" jdbcType="INTEGER"
-                      typeHandler="org.apache.ibatis.type.EnumOrdinalTypeHandler" />
+                      typeHandler="org.apache.ibatis.type.EnumOrdinalTypeHandler" >
+        <property name="forceJavaTypeIntoMapping" value="true" />
+      </columnOverride>
     </table>
     <table tableName="GeneratedAlwaysTest" >
       <columnOverride column="ID_PLUS1" isGeneratedAlways="true" />

--- a/core/mybatis-generator-core/src/test/resources/scripts/generatorConfig-kotlin.xml
+++ b/core/mybatis-generator-core/src/test/resources/scripts/generatorConfig-kotlin.xml
@@ -159,7 +159,7 @@
       <columnOverride column="name" javaType="mbg.test.mb3.common.TestEnum"/>
     </table>
     <table tableName="EnumOrdinalTest">
-      <columnOverride column="enumOrdinal" javaType="mbg.test.mb3.common.TestEnum" jdbcType="INTEGER"
+      <columnOverride column="name" javaType="mbg.test.mb3.common.TestEnum" jdbcType="INTEGER"
                       typeHandler="org.apache.ibatis.type.EnumOrdinalTypeHandler" />
     </table>
     <table tableName="GeneratedAlwaysTest" >

--- a/core/mybatis-generator-core/src/test/resources/scripts/generatorConfig-kotlin.xml
+++ b/core/mybatis-generator-core/src/test/resources/scripts/generatorConfig-kotlin.xml
@@ -158,6 +158,10 @@
     <table tableName="EnumTest">
       <columnOverride column="name" javaType="mbg.test.mb3.common.TestEnum"/>
     </table>
+    <table tableName="EnumOrdinalTest">
+      <columnOverride column="enumOrdinal" javaType="mbg.test.mb3.common.TestEnum" jdbcType="INTEGER"
+                      typeHandler="org.apache.ibatis.type.EnumOrdinalTypeHandler" />
+    </table>
     <table tableName="GeneratedAlwaysTest" >
       <columnOverride column="ID_PLUS1" isGeneratedAlways="true" />
       <columnOverride column="ID_PLUS2" isGeneratedAlways="true" />

--- a/core/mybatis-generator-core/src/test/resources/scripts/generatorConfig.xml
+++ b/core/mybatis-generator-core/src/test/resources/scripts/generatorConfig.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2006-2020 the original author or authors.
+       Copyright 2006-2022 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -229,6 +229,10 @@
     </table>
     <table tableName="EnumTest">
       <columnOverride column="name" javaType="mbg.test.mb3.common.TestEnum"/>
+    </table>
+    <table tableName="EnumOrdinalTest">
+      <columnOverride column="name" javaType="mbg.test.mb3.common.TestEnum" jdbcType="INTEGER"
+                      typeHandler="org.apache.ibatis.type.EnumOrdinalTypeHandler" />
     </table>
     <table tableName="GeneratedAlwaysTest" >
       <columnOverride column="ID_PLUS1" isGeneratedAlways="true" />
@@ -545,6 +549,10 @@
     </table>
     <table tableName="EnumTest">
       <columnOverride column="name" javaType="mbg.test.mb3.common.TestEnum"/>
+    </table>
+    <table tableName="EnumOrdinalTest">
+      <columnOverride column="name" javaType="mbg.test.mb3.common.TestEnum" jdbcType="INTEGER"
+                      typeHandler="org.apache.ibatis.type.EnumOrdinalTypeHandler" />
     </table>
     <table tableName="GeneratedAlwaysTest" >
       <columnOverride column="ID_PLUS1" isGeneratedAlways="true" />

--- a/core/mybatis-generator-core/src/test/resources/scripts/generatorConfig_Dsql.xml
+++ b/core/mybatis-generator-core/src/test/resources/scripts/generatorConfig_Dsql.xml
@@ -166,7 +166,9 @@
     </table>
     <table tableName="EnumOrdinalTest">
       <columnOverride column="name" javaType="mbg.test.mb3.common.TestEnum" jdbcType="INTEGER"
-                      typeHandler="org.apache.ibatis.type.EnumOrdinalTypeHandler" />
+                      typeHandler="org.apache.ibatis.type.EnumOrdinalTypeHandler" >
+        <property name="forceJavaTypeIntoMapping" value="true" />
+      </columnOverride>
     </table>
     <table tableName="GeneratedAlwaysTest" >
       <columnOverride column="ID_PLUS1" isGeneratedAlways="true" />

--- a/core/mybatis-generator-core/src/test/resources/scripts/generatorConfig_Dsql.xml
+++ b/core/mybatis-generator-core/src/test/resources/scripts/generatorConfig_Dsql.xml
@@ -164,6 +164,10 @@
     <table tableName="EnumTest">
       <columnOverride column="name" javaType="mbg.test.mb3.common.TestEnum"/>
     </table>
+    <table tableName="EnumOrdinalTest">
+      <columnOverride column="enumOrdinal" javaType="mbg.test.mb3.common.TestEnum" jdbcType="INTEGER"
+                      typeHandler="org.apache.ibatis.type.EnumOrdinalTypeHandler" />
+    </table>
     <table tableName="GeneratedAlwaysTest" >
       <columnOverride column="ID_PLUS1" isGeneratedAlways="true" />
       <columnOverride column="ID_PLUS2" isGeneratedAlways="true" />

--- a/core/mybatis-generator-core/src/test/resources/scripts/generatorConfig_Dsql.xml
+++ b/core/mybatis-generator-core/src/test/resources/scripts/generatorConfig_Dsql.xml
@@ -165,7 +165,7 @@
       <columnOverride column="name" javaType="mbg.test.mb3.common.TestEnum"/>
     </table>
     <table tableName="EnumOrdinalTest">
-      <columnOverride column="enumOrdinal" javaType="mbg.test.mb3.common.TestEnum" jdbcType="INTEGER"
+      <columnOverride column="name" javaType="mbg.test.mb3.common.TestEnum" jdbcType="INTEGER"
                       typeHandler="org.apache.ibatis.type.EnumOrdinalTypeHandler" />
     </table>
     <table tableName="GeneratedAlwaysTest" >

--- a/core/mybatis-generator-systests-common/src/main/resources/mbg/test/common/scripts/CreateDB.sql
+++ b/core/mybatis-generator-systests-common/src/main/resources/mbg/test/common/scripts/CreateDB.sql
@@ -1,5 +1,5 @@
 --
---    Copyright 2006-2018 the original author or authors.
+--    Copyright 2006-2022 the original author or authors.
 --
 --    Licensed under the Apache License, Version 2.0 (the "License");
 --    you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ drop table mbgtest.Translations if exists;
 drop table CompoundKey if exists;
 drop schema mbgtest if exists;
 drop table EnumTest if exists;
+drop table EnumOrdinalTest if exists;
 drop table GeneratedAlwaysTest if exists;
 drop table GeneratedAlwaysTestNoUpdates if exists;
 drop table IgnoreManyColumns if exists;
@@ -152,6 +153,12 @@ create table CompoundKey (
 create table EnumTest (
   id int not null,
   name varchar(20) not null,
+  primary key(id)
+);
+
+create table EnumOrdinalTest (
+  id int not null,
+  enumOrdinal int not null,
   primary key(id)
 );
 

--- a/core/mybatis-generator-systests-common/src/main/resources/mbg/test/common/scripts/CreateDB.sql
+++ b/core/mybatis-generator-systests-common/src/main/resources/mbg/test/common/scripts/CreateDB.sql
@@ -158,7 +158,7 @@ create table EnumTest (
 
 create table EnumOrdinalTest (
   id int not null,
-  enumOrdinal int not null,
+  name int not null,
   primary key(id)
 );
 

--- a/core/mybatis-generator-systests-kotlin/src/main/resources/generatorConfig.xml
+++ b/core/mybatis-generator-systests-kotlin/src/main/resources/generatorConfig.xml
@@ -160,7 +160,9 @@
     </table>
     <table tableName="EnumOrdinalTest">
       <columnOverride column="name" javaType="mbg.test.mb3.common.TestEnum" jdbcType="INTEGER"
-                      typeHandler="org.apache.ibatis.type.EnumOrdinalTypeHandler" />
+                      typeHandler="org.apache.ibatis.type.EnumOrdinalTypeHandler" >
+        <property name="forceJavaTypeIntoMapping" value="true" />
+      </columnOverride>
     </table>
     <table tableName="GeneratedAlwaysTest" >
       <columnOverride column="ID_PLUS1" isGeneratedAlways="true" />

--- a/core/mybatis-generator-systests-kotlin/src/main/resources/generatorConfig.xml
+++ b/core/mybatis-generator-systests-kotlin/src/main/resources/generatorConfig.xml
@@ -159,7 +159,7 @@
       <columnOverride column="name" javaType="mbg.test.mb3.common.TestEnum"/>
     </table>
     <table tableName="EnumOrdinalTest">
-      <columnOverride column="enumOrdinal" javaType="mbg.test.mb3.common.TestEnum" jdbcType="INTEGER"
+      <columnOverride column="name" javaType="mbg.test.mb3.common.TestEnum" jdbcType="INTEGER"
                       typeHandler="org.apache.ibatis.type.EnumOrdinalTypeHandler" />
     </table>
     <table tableName="GeneratedAlwaysTest" >

--- a/core/mybatis-generator-systests-kotlin/src/main/resources/generatorConfig.xml
+++ b/core/mybatis-generator-systests-kotlin/src/main/resources/generatorConfig.xml
@@ -158,6 +158,10 @@
     <table tableName="EnumTest">
       <columnOverride column="name" javaType="mbg.test.mb3.common.TestEnum"/>
     </table>
+    <table tableName="EnumOrdinalTest">
+      <columnOverride column="enumOrdinal" javaType="mbg.test.mb3.common.TestEnum" jdbcType="INTEGER"
+                      typeHandler="org.apache.ibatis.type.EnumOrdinalTypeHandler" />
+    </table>
     <table tableName="GeneratedAlwaysTest" >
       <columnOverride column="ID_PLUS1" isGeneratedAlways="true" />
       <columnOverride column="ID_PLUS2" isGeneratedAlways="true" />

--- a/core/mybatis-generator-systests-kotlin/src/test/kotlin/mbg/test/mb3/dsql/kotlin/miscellaneous/AbstractAnnotatedMiscellaneousTest.kt
+++ b/core/mybatis-generator-systests-kotlin/src/test/kotlin/mbg/test/mb3/dsql/kotlin/miscellaneous/AbstractAnnotatedMiscellaneousTest.kt
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2006-2020 the original author or authors.
+ *    Copyright 2006-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ abstract class AbstractAnnotatedMiscellaneousTest {
         val environment = Environment("test", JdbcTransactionFactory(), ds)
         val config = Configuration(environment)
         config.addMapper(EnumtestMapper::class.java)
+        config.addMapper(EnumordinaltestMapper::class.java)
         config.addMapper(GeneratedalwaystestMapper::class.java)
         config.addMapper(GeneratedalwaystestnoupdatesMapper::class.java)
         config.addMapper(MyObjectMapper::class.java)

--- a/core/mybatis-generator-systests-kotlin/src/test/kotlin/mbg/test/mb3/dsql/kotlin/miscellaneous/MiscellaneousTest.kt
+++ b/core/mybatis-generator-systests-kotlin/src/test/kotlin/mbg/test/mb3/dsql/kotlin/miscellaneous/MiscellaneousTest.kt
@@ -22,6 +22,7 @@ import mbg.test.mb3.common.TestEnum
 import mbg.test.mb3.generated.dsql.kotlin.miscellaneous.mapper.MyObjectMapper
 import mbg.test.mb3.generated.dsql.kotlin.miscellaneous.mapper.*
 import mbg.test.mb3.generated.dsql.kotlin.miscellaneous.mapper.MyObjectDynamicSqlSupport.myObject
+import mbg.test.mb3.generated.dsql.kotlin.miscellaneous.model.Enumordinaltest
 import mbg.test.mb3.generated.dsql.kotlin.miscellaneous.model.Enumtest
 import mbg.test.mb3.generated.dsql.kotlin.miscellaneous.model.MyObject
 import mbg.test.mb3.generated.dsql.kotlin.miscellaneous.model.Regexrename
@@ -968,6 +969,55 @@ class MiscellaneousTest : AbstractAnnotatedMiscellaneousTest() {
             val returnedRecord = returnedRecords[0]
             assertEquals(1, returnedRecord.id)
             assertEquals(TestEnum.FRED, returnedRecord.name)
+        }
+    }
+
+    @Test
+    fun testEnumOrdinal() {
+        openSession().use { sqlSession ->
+            val mapper = sqlSession.getMapper(EnumordinaltestMapper::class.java)
+
+
+            val enumTest = Enumordinaltest()
+            enumTest.id = 1
+            enumTest.enumordinal = TestEnum.FRED
+
+            val rows = mapper.insert(enumTest)
+            assertEquals(1, rows)
+
+            val returnedRecords = mapper.select { allRows() }
+            assertEquals(1, returnedRecords.size)
+
+            val returnedRecord = returnedRecords[0]
+            assertEquals(1, returnedRecord.id)
+            assertEquals(TestEnum.FRED, returnedRecord.enumordinal)
+        }
+    }
+
+    @Test
+    fun testEnumOrdinalInsertMultiple() {
+        openSession().use { sqlSession ->
+            val mapper = sqlSession.getMapper(EnumordinaltestMapper::class.java)
+            val records = listOf(
+                Enumordinaltest().apply {
+                    id = 1
+                    enumordinal = TestEnum.FRED
+                },
+                Enumordinaltest().apply {
+                    id = 2
+                    enumordinal = TestEnum.BARNEY
+                }
+            )
+
+            val rows = mapper.insertMultiple(records)
+            assertEquals(2, rows)
+
+            val returnedRecords = mapper.select { allRows() }
+            assertEquals(2, returnedRecords.size)
+
+            val returnedRecord = returnedRecords[0]
+            assertEquals(1, returnedRecord.id)
+            assertEquals(TestEnum.FRED, returnedRecord.enumordinal)
         }
     }
 }

--- a/core/mybatis-generator-systests-kotlin/src/test/kotlin/mbg/test/mb3/dsql/kotlin/miscellaneous/MiscellaneousTest.kt
+++ b/core/mybatis-generator-systests-kotlin/src/test/kotlin/mbg/test/mb3/dsql/kotlin/miscellaneous/MiscellaneousTest.kt
@@ -980,7 +980,7 @@ class MiscellaneousTest : AbstractAnnotatedMiscellaneousTest() {
 
             val enumTest = Enumordinaltest()
             enumTest.id = 1
-            enumTest.enumordinal = TestEnum.FRED
+            enumTest.name = TestEnum.FRED
 
             val rows = mapper.insert(enumTest)
             assertEquals(1, rows)
@@ -990,7 +990,7 @@ class MiscellaneousTest : AbstractAnnotatedMiscellaneousTest() {
 
             val returnedRecord = returnedRecords[0]
             assertEquals(1, returnedRecord.id)
-            assertEquals(TestEnum.FRED, returnedRecord.enumordinal)
+            assertEquals(TestEnum.FRED, returnedRecord.name)
         }
     }
 
@@ -1001,11 +1001,11 @@ class MiscellaneousTest : AbstractAnnotatedMiscellaneousTest() {
             val records = listOf(
                 Enumordinaltest().apply {
                     id = 1
-                    enumordinal = TestEnum.FRED
+                    name = TestEnum.FRED
                 },
                 Enumordinaltest().apply {
                     id = 2
-                    enumordinal = TestEnum.BARNEY
+                    name = TestEnum.BARNEY
                 }
             )
 
@@ -1017,7 +1017,7 @@ class MiscellaneousTest : AbstractAnnotatedMiscellaneousTest() {
 
             val returnedRecord = returnedRecords[0]
             assertEquals(1, returnedRecord.id)
-            assertEquals(TestEnum.FRED, returnedRecord.enumordinal)
+            assertEquals(TestEnum.FRED, returnedRecord.name)
         }
     }
 }

--- a/core/mybatis-generator-systests-mybatis3-java8/src/main/resources/generatorConfig.xml
+++ b/core/mybatis-generator-systests-mybatis3-java8/src/main/resources/generatorConfig.xml
@@ -166,7 +166,9 @@
     </table>
     <table tableName="EnumOrdinalTest">
       <columnOverride column="name" javaType="mbg.test.mb3.common.TestEnum" jdbcType="INTEGER"
-                      typeHandler="org.apache.ibatis.type.EnumOrdinalTypeHandler" />
+                      typeHandler="org.apache.ibatis.type.EnumOrdinalTypeHandler" >
+        <property name="forceJavaTypeIntoMapping" value="true" />
+      </columnOverride>
     </table>
     <table tableName="GeneratedAlwaysTest" >
       <columnOverride column="ID_PLUS1" isGeneratedAlways="true" />

--- a/core/mybatis-generator-systests-mybatis3-java8/src/main/resources/generatorConfig.xml
+++ b/core/mybatis-generator-systests-mybatis3-java8/src/main/resources/generatorConfig.xml
@@ -164,6 +164,10 @@
     <table tableName="EnumTest">
       <columnOverride column="name" javaType="mbg.test.mb3.common.TestEnum"/>
     </table>
+    <table tableName="EnumOrdinalTest">
+      <columnOverride column="enumOrdinal" javaType="mbg.test.mb3.common.TestEnum" jdbcType="INTEGER"
+                      typeHandler="org.apache.ibatis.type.EnumOrdinalTypeHandler" />
+    </table>
     <table tableName="GeneratedAlwaysTest" >
       <columnOverride column="ID_PLUS1" isGeneratedAlways="true" />
       <columnOverride column="ID_PLUS2" isGeneratedAlways="true" />

--- a/core/mybatis-generator-systests-mybatis3-java8/src/main/resources/generatorConfig.xml
+++ b/core/mybatis-generator-systests-mybatis3-java8/src/main/resources/generatorConfig.xml
@@ -165,7 +165,7 @@
       <columnOverride column="name" javaType="mbg.test.mb3.common.TestEnum"/>
     </table>
     <table tableName="EnumOrdinalTest">
-      <columnOverride column="enumOrdinal" javaType="mbg.test.mb3.common.TestEnum" jdbcType="INTEGER"
+      <columnOverride column="name" javaType="mbg.test.mb3.common.TestEnum" jdbcType="INTEGER"
                       typeHandler="org.apache.ibatis.type.EnumOrdinalTypeHandler" />
     </table>
     <table tableName="GeneratedAlwaysTest" >

--- a/core/mybatis-generator-systests-mybatis3-java8/src/test/java/mbg/test/mb3/dsql/miscellaneous/AbstractAnnotatedMiscellaneousTest.java
+++ b/core/mybatis-generator-systests-mybatis3-java8/src/test/java/mbg/test/mb3/dsql/miscellaneous/AbstractAnnotatedMiscellaneousTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2006-2020 the original author or authors.
+ *    Copyright 2006-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package mbg.test.mb3.dsql.miscellaneous;
 
 import static mbg.test.common.util.TestUtilities.createDatabase;
 
+import mbg.test.mb3.generated.dsql.miscellaneous.mapper.EnumordinaltestMapper;
 import org.apache.ibatis.datasource.unpooled.UnpooledDataSource;
 import org.apache.ibatis.mapping.Environment;
 import org.apache.ibatis.session.Configuration;
@@ -46,6 +47,7 @@ public abstract class AbstractAnnotatedMiscellaneousTest {
         Environment environment = new Environment("test", new JdbcTransactionFactory(), ds);
         Configuration config = new Configuration(environment);
         config.addMapper(EnumtestMapper.class);
+        config.addMapper(EnumordinaltestMapper.class);
         config.addMapper(GeneratedalwaystestMapper.class);
         config.addMapper(GeneratedalwaystestnoupdatesMapper.class);
         config.addMapper(MyObjectMapper.class);

--- a/core/mybatis-generator-systests-mybatis3-java8/src/test/java/mbg/test/mb3/dsql/miscellaneous/MiscellaneousTest.java
+++ b/core/mybatis-generator-systests-mybatis3-java8/src/test/java/mbg/test/mb3/dsql/miscellaneous/MiscellaneousTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2006-2021 the original author or authors.
+ *    Copyright 2006-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -27,6 +27,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
+import mbg.test.mb3.generated.dsql.miscellaneous.mapper.EnumordinaltestMapper;
+import mbg.test.mb3.generated.dsql.miscellaneous.model.Enumordinaltest;
 import org.apache.ibatis.session.RowBounds;
 import org.apache.ibatis.session.SqlSession;
 import org.junit.jupiter.api.Test;
@@ -996,6 +998,54 @@ public class MiscellaneousTest extends AbstractAnnotatedMiscellaneousTest {
             Enumtest returnedRecord = returnedRecords.get(0);
             assertEquals(1, returnedRecord.getId().intValue());
             assertEquals(TestEnum.FRED, returnedRecord.getName());
+        }
+    }
+
+    @Test
+    public void testEnumOrdinal() {
+        try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+            EnumordinaltestMapper mapper = sqlSession.getMapper(EnumordinaltestMapper.class);
+
+            Enumordinaltest enumTest = new Enumordinaltest();
+            enumTest.setId(1);
+            enumTest.setEnumordinal(TestEnum.FRED);
+            int rows = mapper.insert(enumTest);
+            assertEquals(1, rows);
+
+            List<Enumordinaltest> returnedRecords = mapper.select(SelectDSLCompleter.allRows());
+            assertEquals(1, returnedRecords.size());
+
+            Enumordinaltest returnedRecord = returnedRecords.get(0);
+            assertEquals(1, returnedRecord.getId().intValue());
+            assertEquals(TestEnum.FRED, returnedRecord.getEnumordinal());
+        }
+    }
+
+    @Test
+    public void testEnumOrdinalInsertMultiple() {
+        try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+            EnumordinaltestMapper mapper = sqlSession.getMapper(EnumordinaltestMapper.class);
+            List<Enumordinaltest> records = new ArrayList<>();
+
+            Enumordinaltest enumTest = new Enumordinaltest();
+            enumTest.setId(1);
+            enumTest.setEnumordinal(TestEnum.FRED);
+            records.add(enumTest);
+
+            enumTest = new Enumordinaltest();
+            enumTest.setId(2);
+            enumTest.setEnumordinal(TestEnum.BARNEY);
+            records.add(enumTest);
+
+            int rows = mapper.insertMultiple(records);
+            assertEquals(2, rows);
+
+            List<Enumordinaltest> returnedRecords = mapper.select(SelectDSLCompleter.allRows());
+            assertEquals(2, returnedRecords.size());
+
+            Enumordinaltest returnedRecord = returnedRecords.get(0);
+            assertEquals(1, returnedRecord.getId().intValue());
+            assertEquals(TestEnum.FRED, returnedRecord.getEnumordinal());
         }
     }
 }

--- a/core/mybatis-generator-systests-mybatis3-java8/src/test/java/mbg/test/mb3/dsql/miscellaneous/MiscellaneousTest.java
+++ b/core/mybatis-generator-systests-mybatis3-java8/src/test/java/mbg/test/mb3/dsql/miscellaneous/MiscellaneousTest.java
@@ -1008,7 +1008,7 @@ public class MiscellaneousTest extends AbstractAnnotatedMiscellaneousTest {
 
             Enumordinaltest enumTest = new Enumordinaltest();
             enumTest.setId(1);
-            enumTest.setEnumordinal(TestEnum.FRED);
+            enumTest.setName(TestEnum.FRED);
             int rows = mapper.insert(enumTest);
             assertEquals(1, rows);
 
@@ -1017,7 +1017,7 @@ public class MiscellaneousTest extends AbstractAnnotatedMiscellaneousTest {
 
             Enumordinaltest returnedRecord = returnedRecords.get(0);
             assertEquals(1, returnedRecord.getId().intValue());
-            assertEquals(TestEnum.FRED, returnedRecord.getEnumordinal());
+            assertEquals(TestEnum.FRED, returnedRecord.getName());
         }
     }
 
@@ -1029,12 +1029,12 @@ public class MiscellaneousTest extends AbstractAnnotatedMiscellaneousTest {
 
             Enumordinaltest enumTest = new Enumordinaltest();
             enumTest.setId(1);
-            enumTest.setEnumordinal(TestEnum.FRED);
+            enumTest.setName(TestEnum.FRED);
             records.add(enumTest);
 
             enumTest = new Enumordinaltest();
             enumTest.setId(2);
-            enumTest.setEnumordinal(TestEnum.BARNEY);
+            enumTest.setName(TestEnum.BARNEY);
             records.add(enumTest);
 
             int rows = mapper.insertMultiple(records);
@@ -1045,7 +1045,7 @@ public class MiscellaneousTest extends AbstractAnnotatedMiscellaneousTest {
 
             Enumordinaltest returnedRecord = returnedRecords.get(0);
             assertEquals(1, returnedRecord.getId().intValue());
-            assertEquals(TestEnum.FRED, returnedRecord.getEnumordinal());
+            assertEquals(TestEnum.FRED, returnedRecord.getName());
         }
     }
 }

--- a/core/mybatis-generator-systests-mybatis3/src/main/resources/generatorConfig.xml
+++ b/core/mybatis-generator-systests-mybatis3/src/main/resources/generatorConfig.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2006-2020 the original author or authors.
+       Copyright 2006-2022 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -229,6 +229,10 @@
     </table>
     <table tableName="EnumTest">
       <columnOverride column="name" javaType="mbg.test.mb3.common.TestEnum"/>
+    </table>
+    <table tableName="EnumOrdinalTest">
+      <columnOverride column="name" javaType="mbg.test.mb3.common.TestEnum" jdbcType="INTEGER"
+                      typeHandler="org.apache.ibatis.type.EnumOrdinalTypeHandler" />
     </table>
     <table tableName="GeneratedAlwaysTest" >
       <columnOverride column="ID_PLUS1" isGeneratedAlways="true" />
@@ -545,6 +549,10 @@
     </table>
     <table tableName="EnumTest">
       <columnOverride column="name" javaType="mbg.test.mb3.common.TestEnum"/>
+    </table>
+    <table tableName="EnumOrdinalTest">
+      <columnOverride column="name" javaType="mbg.test.mb3.common.TestEnum" jdbcType="INTEGER"
+                      typeHandler="org.apache.ibatis.type.EnumOrdinalTypeHandler" />
     </table>
     <table tableName="GeneratedAlwaysTest" >
       <columnOverride column="ID_PLUS1" isGeneratedAlways="true" />

--- a/core/mybatis-generator-systests-mybatis3/src/test/java/mbg/test/mb3/annotated/miscellaneous/AbstractAnnotatedMiscellaneousTest.java
+++ b/core/mybatis-generator-systests-mybatis3/src/test/java/mbg/test/mb3/annotated/miscellaneous/AbstractAnnotatedMiscellaneousTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2006-2020 the original author or authors.
+ *    Copyright 2006-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package mbg.test.mb3.annotated.miscellaneous;
 
+import mbg.test.mb3.generated.annotated.miscellaneous.mapper.EnumordinaltestMapper;
 import org.junit.jupiter.api.BeforeEach;
 
 import mbg.test.mb3.AbstractTest;
@@ -31,6 +32,7 @@ public abstract class AbstractAnnotatedMiscellaneousTest extends AbstractTest {
     public void setUp() throws Exception {
         super.setUp();
         sqlSessionFactory.getConfiguration().addMapper(EnumtestMapper.class);
+        sqlSessionFactory.getConfiguration().addMapper(EnumordinaltestMapper.class);
         sqlSessionFactory.getConfiguration().addMapper(MyObjectMapper.class);
         sqlSessionFactory.getConfiguration().addMapper(RegexrenameMapper.class);
         sqlSessionFactory.getConfiguration().addMapper(GeneratedalwaystestMapper.class);

--- a/core/mybatis-generator-systests-mybatis3/src/test/java/mbg/test/mb3/annotated/miscellaneous/MiscellaneousTest.java
+++ b/core/mybatis-generator-systests-mybatis3/src/test/java/mbg/test/mb3/annotated/miscellaneous/MiscellaneousTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2006-2020 the original author or authors.
+ *    Copyright 2006-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -22,6 +22,8 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import mbg.test.mb3.generated.annotated.miscellaneous.mapper.EnumordinaltestMapper;
+import mbg.test.mb3.generated.annotated.miscellaneous.model.Enumordinaltest;
 import org.apache.ibatis.session.SqlSession;
 import org.junit.jupiter.api.Test;
 
@@ -1026,6 +1028,30 @@ public class MiscellaneousTest extends AbstractAnnotatedMiscellaneousTest {
             assertEquals(1, returnedRecords.size());
 
             Enumtest returnedRecord = returnedRecords.get(0);
+            assertEquals(1, returnedRecord.getId().intValue());
+            assertEquals(TestEnum.FRED, returnedRecord.getName());
+        } finally {
+            sqlSession.close();
+        }
+    }
+
+    @Test
+    public void testEnumOrdinal() {
+        SqlSession sqlSession = sqlSessionFactory.openSession();
+
+        try {
+            EnumordinaltestMapper mapper = sqlSession.getMapper(EnumordinaltestMapper.class);
+
+            Enumordinaltest enumTest = new Enumordinaltest();
+            enumTest.setId(1);
+            enumTest.setName(TestEnum.FRED);
+            int rows = mapper.insert(enumTest);
+            assertEquals(1, rows);
+
+            List<Enumordinaltest> returnedRecords = mapper.selectByExample(null);
+            assertEquals(1, returnedRecords.size());
+
+            Enumordinaltest returnedRecord = returnedRecords.get(0);
             assertEquals(1, returnedRecord.getId().intValue());
             assertEquals(TestEnum.FRED, returnedRecord.getName());
         } finally {

--- a/core/mybatis-generator-systests-mybatis3/src/test/java/mbg/test/mb3/miscellaneous/MiscellaneousTest.java
+++ b/core/mybatis-generator-systests-mybatis3/src/test/java/mbg/test/mb3/miscellaneous/MiscellaneousTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2006-2020 the original author or authors.
+ *    Copyright 2006-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -28,6 +28,8 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import mbg.test.mb3.generated.miscellaneous.mapper.EnumordinaltestMapper;
+import mbg.test.mb3.generated.miscellaneous.model.Enumordinaltest;
 import org.apache.ibatis.session.SqlSession;
 import org.junit.jupiter.api.Test;
 
@@ -1110,6 +1112,30 @@ public class MiscellaneousTest extends AbstractMiscellaneousTest {
             assertEquals(1, returnedRecords.size());
 
             Enumtest returnedRecord = returnedRecords.get(0);
+            assertEquals(1, returnedRecord.getId().intValue());
+            assertEquals(TestEnum.FRED, returnedRecord.getName());
+        } finally {
+            sqlSession.close();
+        }
+    }
+
+    @Test
+    public void testEnumOrdinal() {
+        SqlSession sqlSession = sqlSessionFactory.openSession();
+
+        try {
+            EnumordinaltestMapper mapper = sqlSession.getMapper(EnumordinaltestMapper.class);
+
+            Enumordinaltest enumTest = new Enumordinaltest();
+            enumTest.setId(1);
+            enumTest.setName(TestEnum.FRED);
+            int rows = mapper.insert(enumTest);
+            assertEquals(1, rows);
+
+            List<Enumordinaltest> returnedRecords = mapper.selectByExample(null);
+            assertEquals(1, returnedRecords.size());
+
+            Enumordinaltest returnedRecord = returnedRecords.get(0);
             assertEquals(1, returnedRecord.getId().intValue());
             assertEquals(TestEnum.FRED, returnedRecord.getName());
         } finally {

--- a/core/mybatis-generator-systests-mybatis3/src/test/resources/mbg/test/mb3/miscellaneous/MapperConfig.xml
+++ b/core/mybatis-generator-systests-mybatis3/src/test/resources/mbg/test/mb3/miscellaneous/MapperConfig.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
 
-       Copyright 2006-2016 the original author or authors.
+       Copyright 2006-2022 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -48,6 +48,7 @@
     <mapper resource="mbg/test/mb3/generated/miscellaneous/xml/MyMapper.xml" />
     <mapper resource="mbg/test/mb3/generated/miscellaneous/xml/RegexrenameMapper.xml" />
     <mapper resource="mbg/test/mb3/generated/miscellaneous/xml/EnumtestMapper.xml" />
+    <mapper resource="mbg/test/mb3/generated/miscellaneous/xml/EnumordinaltestMapper.xml" />
     <mapper resource="mbg/test/mb3/generated/miscellaneous/xml/GeneratedalwaystestMapper.xml" />
     <mapper resource="mbg/test/mb3/generated/miscellaneous/xml/GeneratedalwaystestnoupdatesMapper.xml" />
     <mapper resource="mbg/test/mb3/generated/miscellaneous/xml/IgnoremanycolumnsMapper.xml" />

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -273,7 +273,7 @@
       <dependency>
         <groupId>org.mybatis.dynamic-sql</groupId>
         <artifactId>mybatis-dynamic-sql</artifactId>
-        <version>1.4.0-SNAPSHOT</version>
+        <version>1.4.0</version>
       </dependency>
       <dependency>
         <groupId>org.jetbrains.kotlin</groupId>


### PR DESCRIPTION
This is useful in runtimes that target MyBatis Dynamic SQL. If you were to use a type handler like MyBatis' EnumOrdinalTypeHandler the java type is required in the mapping.

Resolves #742 