### PR TITLE
Add KotlinType companion object and KotlinProperty const

### DIFF
--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/kotlin/KotlinModifier.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/kotlin/KotlinModifier.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2006-2020 the original author or authors.
+ *    Copyright 2006-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -20,7 +20,8 @@ public enum KotlinModifier {
     PUBLIC("public"), //$NON-NLS-1$
     PRIVATE("private"), //$NON-NLS-1$
     DATA("data"), //$NON-NLS-1$
-    LATE_INIT("lateinit"); //$NON-NLS-1$
+    LATE_INIT("lateinit"), //$NON-NLS-1$
+    CONST("const"); //$NON-NLS-1$
 
     private final String value;
 

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/kotlin/KotlinType.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/kotlin/KotlinType.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2006-2021 the original author or authors.
+ *    Copyright 2006-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import java.util.Set;
 
 public class KotlinType extends KotlinNamedItemContainer {
 
+    public static final String DEFAULT_COMPANION_OBJECT_NAME = "companion";
     private final List<KotlinProperty> constructorProperties = new ArrayList<>();
     private final Type type;
     private final Set<String> superTypes = new HashSet<>();
@@ -30,7 +31,8 @@ public class KotlinType extends KotlinNamedItemContainer {
     public enum Type {
         CLASS("class"), //$NON-NLS-1$
         INTERFACE("interface"), //$NON-NLS-1$
-        OBJECT("object"); //$NON-NLS-1$
+        OBJECT("object"), //$NON-NLS-1$
+        COMPANION_OBJECT("companion object"); //$NON-NLS-1$
 
         private final String value;
 
@@ -85,6 +87,13 @@ public class KotlinType extends KotlinNamedItemContainer {
 
     public static Builder newObject(String name) {
         return new Builder(Type.OBJECT, name);
+    }
+
+    public static Builder newCompanionObject() {
+        return new Builder(Type.COMPANION_OBJECT, DEFAULT_COMPANION_OBJECT_NAME);
+    }
+    public static Builder newCompanionObject(String name) {
+        return new Builder(Type.COMPANION_OBJECT, name);
     }
 
     public static class Builder extends NamedItemContainerBuilder<Builder> {

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/kotlin/render/KotlinTypeRenderer.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/kotlin/render/KotlinTypeRenderer.java
@@ -33,9 +33,16 @@ public class KotlinTypeRenderer {
 
         List<String> answer = new ArrayList<>(kotlinType.getAnnotations());
 
-        String renderedModifiersAndName = KotlinRenderingUtilities.renderModifiers(kotlinType.getModifiers())
-                + kotlinType.getType().getValue() + " " //$NON-NLS-1$
-                + kotlinType.getName();
+        String renderedModifiers = KotlinRenderingUtilities.renderModifiers(kotlinType.getModifiers())
+            + kotlinType.getType().getValue(); //$NON-NLS-1$
+
+        String renderedModifiersAndName;
+        if (kotlinType.getType() == KotlinType.Type.COMPANION_OBJECT && kotlinType.getName().equals(KotlinType.DEFAULT_COMPANION_OBJECT_NAME)) {
+            renderedModifiersAndName = renderedModifiers;
+        } else {
+            renderedModifiersAndName = renderedModifiers + " " + kotlinType.getName(); //$NON-NLS-1$
+        }
+
         String renderedSuperTypes = kotlinType.getSuperTypes().stream()
                 .sorted()
                 .collect(CustomCollectors.joining(", ", " : ", "")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$

--- a/core/mybatis-generator-core/src/test/kotlin/org/mybatis/generator/api/dom/kotlin/render/KotlinTypeTest.kt
+++ b/core/mybatis-generator-core/src/test/kotlin/org/mybatis/generator/api/dom/kotlin/render/KotlinTypeTest.kt
@@ -326,4 +326,139 @@ class KotlinTypeTest {
             |class Adder : Serializable
             """.trimMargin())
     }
+
+    @Test
+    fun testDataClassWithCompanionObjectAndConstVal() {
+        val obj = KotlinType.newClass("Adder")
+            .withModifier(KotlinModifier.DATA)
+            .withConstructorProperty(KotlinProperty.newVal("a")
+                .withDataType("Int")
+                .build())
+            .withNamedItem(KotlinFunction.newOneLineFunction("adjustWithConstant")
+                .withCodeLine("addConstant(a)")
+                .build())
+            .withNamedItem(KotlinType.newCompanionObject()
+                .withNamedItem(KotlinProperty.newVal("VALUE_TO_ADD")
+                    .withModifier(KotlinModifier.CONST)
+                    .withDataType("Int")
+                    .withInitializationString("42")
+                    .build())
+                .withNamedItem(KotlinFunction.newOneLineFunction("addConstant")
+                    .withArgument(KotlinArg.newArg("a").withDataType("Int").build())
+                    .withExplicitReturnType("Int")
+                    .withCodeLine("VALUE_TO_ADD + a")
+                    .build())
+                .build()
+            )
+            .build()
+
+        val renderedType = KotlinTypeRenderer().render(obj).stream()
+            .collect(Collectors.joining(System.getProperty("line.separator")))
+
+        assertThat(renderedType).isEqualToNormalizingNewlines("""
+            |data class Adder(
+            |    val a: Int
+            |) {
+            |    fun adjustWithConstant() =
+            |        addConstant(a)
+            |
+            |    companion object {
+            |        const val VALUE_TO_ADD: Int = 42
+            |
+            |        fun addConstant(a: Int): Int =
+            |            VALUE_TO_ADD + a
+            |    }
+            |}
+            """.trimMargin())
+    }
+
+    @Test
+    fun testRegularClassWithCompanionObjectAndConstVal() {
+        val obj = KotlinType.newClass("Adder")
+            .withConstructorProperty(KotlinProperty.newVal("a")
+                .withDataType("Int")
+                .build())
+            .withNamedItem(KotlinFunction.newOneLineFunction("adjustWithConstant")
+                .withCodeLine("addConstant(a)")
+                .build())
+            .withNamedItem(KotlinType.newCompanionObject()
+                .withNamedItem(KotlinProperty.newVal("VALUE_TO_ADD")
+                    .withModifier(KotlinModifier.CONST)
+                    .withDataType("Int")
+                    .withInitializationString("42")
+                    .build())
+                .withNamedItem(KotlinFunction.newOneLineFunction("addConstant")
+                    .withArgument(KotlinArg.newArg("a").withDataType("Int").build())
+                    .withExplicitReturnType("Int")
+                    .withCodeLine("VALUE_TO_ADD + a")
+                    .build())
+                .build()
+            )
+            .build()
+
+        val renderedType = KotlinTypeRenderer().render(obj).stream()
+            .collect(Collectors.joining(System.getProperty("line.separator")))
+
+        assertThat(renderedType).isEqualToNormalizingNewlines("""
+            |class Adder(
+            |    val a: Int
+            |) {
+            |    fun adjustWithConstant() =
+            |        addConstant(a)
+            |
+            |    companion object {
+            |        const val VALUE_TO_ADD: Int = 42
+            |
+            |        fun addConstant(a: Int): Int =
+            |            VALUE_TO_ADD + a
+            |    }
+            |}
+            """.trimMargin())
+    }
+
+    @Test
+    fun testRegularClassWithNamedCompanionObjectAndConstVal() {
+        val obj = KotlinType.newClass("Adder")
+            .withConstructorProperty(KotlinProperty.newVal("a")
+                .withDataType("Int")
+                .build())
+            .withNamedItem(KotlinFunction.newOneLineFunction("adjustWithConstant")
+                .withCodeLine("addConstant(a)")
+                .build())
+            .withNamedItem(KotlinType.newCompanionObject("Util")
+                .withNamedItem(KotlinProperty.newVal("VALUE_TO_ADD")
+                    .withModifier(KotlinModifier.CONST)
+                    .withDataType("Int")
+                    .withInitializationString("42")
+                    .build())
+                .withNamedItem(KotlinFunction.newOneLineFunction("addConstant")
+                    .withAnnotation("@JvmStatic")
+                    .withArgument(KotlinArg.newArg("a").withDataType("Int").build())
+                    .withExplicitReturnType("Int")
+                    .withCodeLine("VALUE_TO_ADD + a")
+                    .build())
+                .build()
+            )
+            .build()
+
+        val renderedType = KotlinTypeRenderer().render(obj).stream()
+            .collect(Collectors.joining(System.getProperty("line.separator")))
+
+        assertThat(renderedType).isEqualToNormalizingNewlines("""
+            |class Adder(
+            |    val a: Int
+            |) {
+            |    fun adjustWithConstant() =
+            |        addConstant(a)
+            |
+            |    companion object Util {
+            |        const val VALUE_TO_ADD: Int = 42
+            |
+            |        @JvmStatic
+            |        fun addConstant(a: Int): Int =
+            |            VALUE_TO_ADD + a
+            |    }
+            |}
+            """.trimMargin())
+    }
 }


### PR DESCRIPTION
The current Kotlin DSL does not yet allow for creating companion objects and/or const val's. Having this ability is useful for a number of reasons. One specific reason is to generate constants for column names. This allows custom result mappings to be a bit more typesafe, reducing the scope of typing errors further.

Example of a generated DynamicSqlSupport class and a custom mapper with typesafe columns:
[mybatis-generator-pull-request.txt](https://github.com/mybatis/generator/files/9298774/mybatis-generator-pull-request.txt)

