### PR TITLE
[pom] Remove unncessary junit 5 items

### DIFF
--- a/core/mybatis-generator-core/pom.xml
+++ b/core/mybatis-generator-core/pom.xml
@@ -196,19 +196,11 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-launcher</artifactId>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>

--- a/core/mybatis-generator-systests-kotlin/pom.xml
+++ b/core/mybatis-generator-systests-kotlin/pom.xml
@@ -35,15 +35,7 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-launcher</artifactId>
     </dependency>
     <dependency>
       <groupId>org.mybatis</groupId>

--- a/core/mybatis-generator-systests-mybatis3-java8/pom.xml
+++ b/core/mybatis-generator-systests-mybatis3-java8/pom.xml
@@ -109,15 +109,7 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-launcher</artifactId>
     </dependency>
     <dependency>
       <groupId>org.mybatis</groupId>

--- a/core/mybatis-generator-systests-mybatis3/pom.xml
+++ b/core/mybatis-generator-systests-mybatis3/pom.xml
@@ -99,15 +99,7 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-launcher</artifactId>
     </dependency>
     <dependency>
       <groupId>org.mybatis</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -60,7 +60,6 @@
     <formatter.config>eclipse-formatter-config-4space.xml</formatter.config>
     <kotlin.version>1.7.10</kotlin.version>
     <junit.jupiter.version>5.9.0</junit.jupiter.version>
-    <junit.platform.version>1.9.0</junit.platform.version>
     <argLine>-Djdk.attach.allowAttachSelf -Xmx1024m -Duser.timezone=UTC</argLine>
   </properties>
 
@@ -199,12 +198,6 @@
       </dependency>
       <dependency>
         <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-api</artifactId>
-        <version>${junit.jupiter.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-params</artifactId>
         <version>${junit.jupiter.version}</version>
         <scope>test</scope>
@@ -213,12 +206,6 @@
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-engine</artifactId>
         <version>${junit.jupiter.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.platform</groupId>
-        <artifactId>junit-platform-launcher</artifactId>
-        <version>${junit.platform.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
The launcher was only needed long time ago when intellij didn't properly support junit.  Its not needed in the build now.  The api is tehre due to others so no need to directly define.