### PR TITLE
Update hsqldb v2.7.1

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -55,7 +55,7 @@
   <properties>
     <findbugs.onlyAnalyze>org.mybatis.generator.*</findbugs.onlyAnalyze>
     <clirr.comparisonVersion>1.3.2</clirr.comparisonVersion>
-    <hsqldb.version>2.7.0</hsqldb.version>
+    <hsqldb.version>2.7.1</hsqldb.version>
     <checkstyle.config>${project.basedir}/checkstyle-override.xml</checkstyle.config>
     <formatter.config>eclipse-formatter-config-4space.xml</formatter.config>
     <kotlin.version>1.7.20</kotlin.version>


### PR DESCRIPTION
Update hsqldb v2.7.0 -> v2.7.1
https://nvd.nist.gov/vuln/detail/CVE-2022-41853