### PR TITLE
Add ability to provide a fine grained filter for tables in a context

### DIFF
--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/CompositePlugin.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/CompositePlugin.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2006-2022 the original author or authors.
+ *    Copyright 2006-2023 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -1258,6 +1258,17 @@ public abstract class CompositePlugin implements Plugin {
             IntrospectedTable introspectedTable) {
         for (Plugin plugin : plugins) {
             if (!plugin.clientUpdateByPrimaryKeyMethodGenerated(kotlinFunction, kotlinFile, introspectedTable)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean shouldGenerate(IntrospectedTable introspectedTable) {
+        for (Plugin plugin : plugins) {
+            if (!plugin.shouldGenerate(introspectedTable)) {
                 return false;
             }
         }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/Plugin.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/Plugin.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2006-2022 the original author or authors.
+ *    Copyright 2006-2023 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -2032,6 +2032,16 @@ public interface Plugin {
 
     default boolean clientUpdateByPrimaryKeyMethodGenerated(KotlinFunction kotlinFunction, KotlinFile kotlinFile,
             IntrospectedTable introspectedTable) {
+        return true;
+    }
+
+    /**
+     * If false, the table will be skipped in code generation.
+     *
+     * @param introspectedTable the current table
+     * @return true if code should be generated for this table, else false
+     */
+    default boolean shouldGenerate(IntrospectedTable introspectedTable) {
         return true;
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/config/Context.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/config/Context.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2006-2022 the original author or authors.
+ *    Copyright 2006-2023 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -459,6 +459,11 @@ public class Context extends PropertyHolder {
 
         for (IntrospectedTable introspectedTable : introspectedTables) {
             callback.checkCancel();
+
+            if (!pluginAggregator.shouldGenerate(introspectedTable)) {
+                continue;
+            }
+
             generatedJavaFiles.addAll(introspectedTable
                     .getGeneratedJavaFiles());
             generatedXmlFiles.addAll(introspectedTable

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/plugins/IgnoreViewsPlugin.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/plugins/IgnoreViewsPlugin.java
@@ -31,6 +31,6 @@ public class IgnoreViewsPlugin extends PluginAdapter {
 
     @Override
     public boolean shouldGenerate(IntrospectedTable introspectedTable) {
-        return !"VIEW".equals(introspectedTable.getTableType()); //$NON-NLS-1$
+        return !"VIEW".equalsIgnoreCase(introspectedTable.getTableType()); //$NON-NLS-1$
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/plugins/IgnoreViewsPlugin.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/plugins/IgnoreViewsPlugin.java
@@ -1,0 +1,36 @@
+/*
+ *    Copyright 2006-2023 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.generator.plugins;
+
+import org.mybatis.generator.api.IntrospectedTable;
+import org.mybatis.generator.api.PluginAdapter;
+
+import java.util.List;
+
+/**
+ * This plugin will cause any table of type "VIEW" in a context to be ignored.
+ */
+public class IgnoreViewsPlugin extends PluginAdapter {
+    @Override
+    public boolean validate(List<String> warnings) {
+        return true;
+    }
+
+    @Override
+    public boolean shouldGenerate(IntrospectedTable introspectedTable) {
+        return !"VIEW".equals(introspectedTable.getTableType()); //$NON-NLS-1$
+    }
+}

--- a/core/mybatis-generator-core/src/site/xhtml/reference/plugins.xhtml
+++ b/core/mybatis-generator-core/src/site/xhtml/reference/plugins.xhtml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2006-2022 the original author or authors.
+       Copyright 2006-2023 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -118,6 +118,11 @@ The plugin will create the additional Methods:
 
 <p>Using this plugin, you can configure the property values fluently with chained method calls. Example: <code>new MyDomain().withFoo("Test").withBar(4711);</code></p>
 
+
+<h2>org.mybatis.generator.plugins.IgnoreViewsPlugin</h2>
+<p>This plugin will filter out any table of type "VIEW" from a code generation run. This can be useful if you use
+    a wildcard to select many tables and views, but don't want to generate code for the views.
+</p>
 
 <h2>org.mybatis.generator.plugins.MapperAnnotationPlugin</h2>
 <p>This plugin has no impact and is not needed when the target runtime in use is based on MyBatis Dynamic SQL.</p>

--- a/core/mybatis-generator-core/src/site/xhtml/whatsNew.xhtml
+++ b/core/mybatis-generator-core/src/site/xhtml/whatsNew.xhtml
@@ -40,6 +40,9 @@
       Logging should now work as expected in Maven - Maven ships with the SLF4J simple logger in the classpath, so
       configuring logging in Maven will always use the SLF simple logger.
   </li>
+  <li>Added a new plugin method "shouldGenerate" that can be used to provide fine-grained filtering of tables in a
+      context. Also added a new "IgnoreViewsPlugin" that filters out table type VIEW
+  </li>
 </ul>
 
 

--- a/core/mybatis-generator-core/src/test/resources/scripts/generatorConfig.xml
+++ b/core/mybatis-generator-core/src/test/resources/scripts/generatorConfig.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2006-2022 the original author or authors.
+       Copyright 2006-2023 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -905,5 +905,18 @@
       <columnOverride column="id7$$" delimitedColumnName="true" />
       <columnOverride column="class" property="dbClass" />
     </table>
+  </context>
+
+  <context id="nothing-generated" targetRuntime="MyBatis3Simple">
+    <plugin type="org.mybatis.generator.plugins.IgnoreViewsPlugin" />
+
+    <jdbcConnection driverClass="org.hsqldb.jdbcDriver" connectionURL="${database.url}" userId="sa" />
+
+    <javaModelGenerator targetPackage="mbg.test.mb3.generated.simpleannotated.nothing" targetProject="MAVEN"/>
+
+    <javaClientGenerator type="ANNOTATEDMAPPER" targetPackage="mbg.test.mb3.generated.simpleannotated.nothing"  targetProject="MAVEN"/>
+
+    <table tableName="NameView" />
+    <table tableName="PKFields" />
   </context>
 </generatorConfiguration>

--- a/core/mybatis-generator-systests-mybatis3/pom.xml
+++ b/core/mybatis-generator-systests-mybatis3/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2006-2022 the original author or authors.
+       Copyright 2006-2023 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -109,6 +109,10 @@
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
     </dependency>
   </dependencies>
   <description>Tests for the MyBatis3 code generator.</description>

--- a/core/mybatis-generator-systests-mybatis3/src/main/resources/generatorConfig.xml
+++ b/core/mybatis-generator-systests-mybatis3/src/main/resources/generatorConfig.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2006-2022 the original author or authors.
+       Copyright 2006-2023 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -905,5 +905,18 @@
       <columnOverride column="id7$$" delimitedColumnName="true" />
       <columnOverride column="class" property="dbClass" />
     </table>
+  </context>
+
+  <context id="nothing-generated" targetRuntime="MyBatis3Simple">
+    <plugin type="org.mybatis.generator.plugins.IgnoreViewsPlugin" />
+
+    <jdbcConnection driverClass="org.hsqldb.jdbcDriver" connectionURL="${database.url}" userId="sa" />
+
+    <javaModelGenerator targetPackage="mbg.test.mb3.generated.simpleannotated.nothing" targetProject="MAVEN"/>
+
+    <javaClientGenerator type="ANNOTATEDMAPPER" targetPackage="mbg.test.mb3.generated.simpleannotated.nothing"  targetProject="MAVEN"/>
+
+    <table tableName="NameView" />
+    <table tableName="PKFields" />
   </context>
 </generatorConfiguration>

--- a/core/mybatis-generator-systests-mybatis3/src/test/java/mbg/test/mb3/simpleannotated/SimpleAnnotatedTest.java
+++ b/core/mybatis-generator-systests-mybatis3/src/test/java/mbg/test/mb3/simpleannotated/SimpleAnnotatedTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2006-2022 the original author or authors.
+ *    Copyright 2006-2023 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package mbg.test.mb3.simpleannotated;
 
 import static mbg.test.common.util.TestUtilities.datesAreEqual;
 import static mbg.test.common.util.TestUtilities.timesAreEqual;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.math.BigDecimal;
@@ -463,5 +464,19 @@ public class SimpleAnnotatedTest extends AbstractSimpleAnnotatedTest {
         } finally {
             sqlSession.close();
         }
+    }
+
+    @Test
+    void testThatViewWasIgnored() throws ClassNotFoundException {
+        Class<?> goodClass = Class.forName("mbg.test.mb3.generated.simpleannotated.nothing.Pkfields");
+        assertNotNull(goodClass);
+
+        assertThatExceptionOfType(ClassNotFoundException.class).isThrownBy(() -> {
+            Class.forName("mbg.test.mb3.generated.simpleannotated.nothing.Nameview");
+        });
+
+        assertThatExceptionOfType(ClassNotFoundException.class).isThrownBy(() -> {
+            Class.forName("mbg.test.mb3.generated.simpleannotated.nothing.NameviewMapper");
+        });
     }
 }

--- a/core/mybatis-generator-systests-mybatis3/src/test/java/mbg/test/mb3/simpleannotated/SimpleAnnotatedTest.java
+++ b/core/mybatis-generator-systests-mybatis3/src/test/java/mbg/test/mb3/simpleannotated/SimpleAnnotatedTest.java
@@ -47,9 +47,7 @@ public class SimpleAnnotatedTest extends AbstractSimpleAnnotatedTest {
 
     @Test
     public void testAwfulTable() {
-        SqlSession sqlSession = sqlSessionFactory.openSession();
-
-        try {
+        try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
             AwfulTableMapper mapper = sqlSession.getMapper(AwfulTableMapper.class);
 
             AwfulTable record = new AwfulTable();
@@ -84,18 +82,13 @@ public class SimpleAnnotatedTest extends AbstractSimpleAnnotatedTest {
 
             records = mapper.selectAll();
             assertEquals(1, records.size());
-
-        } finally {
-            sqlSession.close();
         }
     }
 
 
     @Test
     public void testPKFieldsInsert() {
-        SqlSession sqlSession = sqlSessionFactory.openSession();
-
-        try {
+        try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
             PkfieldsMapper mapper = sqlSession.getMapper(PkfieldsMapper.class);
             Pkfields record = new Pkfields();
             record.setDatefield(new Date());
@@ -133,16 +126,12 @@ public class SimpleAnnotatedTest extends AbstractSimpleAnnotatedTest {
                     .getTimefield()));
             assertEquals(record.getTimestampfield(), returnedRecord
                     .getTimestampfield());
-        } finally {
-            sqlSession.close();
         }
     }
 
     @Test
     public void testPKFieldsUpdateByPrimaryKey() {
-        SqlSession sqlSession = sqlSessionFactory.openSession();
-
-        try {
+        try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
             PkfieldsMapper mapper = sqlSession.getMapper(PkfieldsMapper.class);
             Pkfields record = new Pkfields();
             record.setFirstname("Jeff");
@@ -165,16 +154,12 @@ public class SimpleAnnotatedTest extends AbstractSimpleAnnotatedTest {
             assertEquals(record.getLastname(), record2.getLastname());
             assertEquals(record.getId1(), record2.getId1());
             assertEquals(record.getId2(), record2.getId2());
-        } finally {
-            sqlSession.close();
         }
     }
 
     @Test
     public void testPKfieldsDeleteByPrimaryKey() {
-        SqlSession sqlSession = sqlSessionFactory.openSession();
-
-        try {
+        try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
             PkfieldsMapper mapper = sqlSession.getMapper(PkfieldsMapper.class);
             Pkfields record = new Pkfields();
             record.setFirstname("Jeff");
@@ -189,16 +174,12 @@ public class SimpleAnnotatedTest extends AbstractSimpleAnnotatedTest {
 
             List<Pkfields> answer = mapper.selectAll();
             assertEquals(0, answer.size());
-        } finally {
-            sqlSession.close();
         }
     }
 
     @Test
     public void testPKFieldsSelectByPrimaryKey() {
-        SqlSession sqlSession = sqlSessionFactory.openSession();
-
-        try {
+        try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
             PkfieldsMapper mapper = sqlSession.getMapper(PkfieldsMapper.class);
             Pkfields record = new Pkfields();
             record.setFirstname("Jeff");
@@ -221,16 +202,12 @@ public class SimpleAnnotatedTest extends AbstractSimpleAnnotatedTest {
             assertEquals(record.getLastname(), newRecord.getLastname());
             assertEquals(record.getId1(), newRecord.getId1());
             assertEquals(record.getId2(), newRecord.getId2());
-        } finally {
-            sqlSession.close();
         }
     }
 
     @Test
     public void testPKFieldsSelectAll() {
-        SqlSession sqlSession = sqlSessionFactory.openSession();
-
-        try {
+        try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
             PkfieldsMapper mapper = sqlSession.getMapper(PkfieldsMapper.class);
             Pkfields record = new Pkfields();
             record.setFirstname("Fred");
@@ -276,16 +253,12 @@ public class SimpleAnnotatedTest extends AbstractSimpleAnnotatedTest {
 
             List<Pkfields> answer = mapper.selectAll();
             assertEquals(6, answer.size());
-        } finally {
-            sqlSession.close();
         }
     }
 
     @Test
     public void testFieldsOnly() {
-        SqlSession sqlSession = sqlSessionFactory.openSession();
-
-        try {
+        try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
             FieldsonlyMapper mapper = sqlSession.getMapper(FieldsonlyMapper.class);
 
             Fieldsonly record = new Fieldsonly();
@@ -303,17 +276,12 @@ public class SimpleAnnotatedTest extends AbstractSimpleAnnotatedTest {
             List<Fieldsonly> records = mapper.selectAll();
 
             assertEquals(2, records.size());
-
-        } finally {
-            sqlSession.close();
         }
     }
 
     @Test
     public void testFieldsblobs() {
-        SqlSession sqlSession = sqlSessionFactory.openSession();
-
-        try {
+        try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
             FieldsblobsMapper mapper = sqlSession.getMapper(FieldsblobsMapper.class);
 
             Fieldsblobs record = new Fieldsblobs();
@@ -329,17 +297,12 @@ public class SimpleAnnotatedTest extends AbstractSimpleAnnotatedTest {
             List<Fieldsblobs> records = mapper.selectAll();
 
             assertEquals(2, records.size());
-
-        } finally {
-            sqlSession.close();
         }
     }
 
     @Test
     public void testPkblobs() {
-        SqlSession sqlSession = sqlSessionFactory.openSession();
-
-        try {
+        try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
             PkblobsMapper mapper = sqlSession.getMapper(PkblobsMapper.class);
 
             Pkblobs record = new Pkblobs();
@@ -374,17 +337,12 @@ public class SimpleAnnotatedTest extends AbstractSimpleAnnotatedTest {
 
             records = mapper.selectAll();
             assertEquals(1, records.size());
-
-        } finally {
-            sqlSession.close();
         }
     }
 
     @Test
     public void testPkfieldsblobs() {
-        SqlSession sqlSession = sqlSessionFactory.openSession();
-
-        try {
+        try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
             PkfieldsblobsMapper mapper = sqlSession.getMapper(PkfieldsblobsMapper.class);
 
             Pkfieldsblobs record = new Pkfieldsblobs();
@@ -421,17 +379,12 @@ public class SimpleAnnotatedTest extends AbstractSimpleAnnotatedTest {
 
             records = mapper.selectAll();
             assertEquals(1, records.size());
-
-        } finally {
-            sqlSession.close();
         }
     }
 
     @Test
     public void testPkonly() {
-        SqlSession sqlSession = sqlSessionFactory.openSession();
-
-        try {
+        try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
             PkonlyMapper mapper = sqlSession.getMapper(PkonlyMapper.class);
 
             Pkonly record = new Pkonly();
@@ -461,8 +414,6 @@ public class SimpleAnnotatedTest extends AbstractSimpleAnnotatedTest {
 
             records = mapper.selectAll();
             assertEquals(3, records.size());
-        } finally {
-            sqlSession.close();
         }
     }
 
@@ -471,12 +422,10 @@ public class SimpleAnnotatedTest extends AbstractSimpleAnnotatedTest {
         Class<?> goodClass = Class.forName("mbg.test.mb3.generated.simpleannotated.nothing.Pkfields");
         assertNotNull(goodClass);
 
-        assertThatExceptionOfType(ClassNotFoundException.class).isThrownBy(() -> {
-            Class.forName("mbg.test.mb3.generated.simpleannotated.nothing.Nameview");
-        });
+        assertThatExceptionOfType(ClassNotFoundException.class).isThrownBy(() ->
+                Class.forName("mbg.test.mb3.generated.simpleannotated.nothing.Nameview"));
 
-        assertThatExceptionOfType(ClassNotFoundException.class).isThrownBy(() -> {
-            Class.forName("mbg.test.mb3.generated.simpleannotated.nothing.NameviewMapper");
-        });
+        assertThatExceptionOfType(ClassNotFoundException.class).isThrownBy(() ->
+                Class.forName("mbg.test.mb3.generated.simpleannotated.nothing.NameviewMapper"));
     }
 }


### PR DESCRIPTION
The specific ask was for a method of ignoring table type of VIEW. The new plugin method "shouldGenerate" is very flexible and can be used to filter tables out of a generation run for any reason.

Also added a new plugin to demonstrate the new function.

Resolves #840 
