### PR TITLE
[mvn] Update maven wrapper and use secure license

### DIFF
--- a/core/.mvn/maven.config
+++ b/core/.mvn/maven.config
@@ -1,1 +1,2 @@
 -Daether.checksums.algorithms=SHA-512,SHA-256,SHA-1,MD5
+-Daether.connector.smartChecksums=false

--- a/core/.mvn/settings.xml
+++ b/core/.mvn/settings.xml
@@ -24,8 +24,13 @@
       <username>${env.CI_DEPLOY_USERNAME}</username>
       <password>${env.CI_DEPLOY_PASSWORD}</password>
     </server>
+    <!-- Used for gh-pages-scm publish via maven-scm-publish-plugin -->
     <server>
-      <id>gh-pages</id>
+      <id>gh-pages-scm</id>
+      <configuration>
+        <scmVersionType>branch</scmVersionType>
+        <scmVersion>gh-pages</scmVersion>
+      </configuration>
     </server>
     <server>
       <id>github</id>

--- a/core/.mvn/wrapper/maven-wrapper.properties
+++ b/core/.mvn/wrapper/maven-wrapper.properties
@@ -6,7 +6,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/core/mvnw
+++ b/core/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/core/mvnw.cmd
+++ b/core/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an


### PR DESCRIPTION
preps for future restore of site deploy

The maven.config item ensures we are still pulling stronger checksums.  Without that it uses the header and will generally pull sha-1.