### PR TITLE
[pom] Rework distro management for site on generator

### DIFF
--- a/core/mybatis-generator-core/pom.xml
+++ b/core/mybatis-generator-core/pom.xml
@@ -37,9 +37,9 @@
 
   <distributionManagement>
     <site>
-      <id>gh-pages</id>
-      <name>Mybatis Generator GitHub Pages</name>
-      <url>git:ssh://git@github.com/mybatis/generator.git?gh-pages#</url>
+      <id>gh-pages-scm</id>
+      <name>Mybatis GitHub Pages</name>
+      <url>scm:git:ssh://git@github.com/mybatis/generator.git</url>
     </site>
   </distributionManagement>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -62,6 +62,13 @@
     <system>Github</system>
     <url>https://github.com/mybatis/generator/actions</url>
   </ciManagement>
+  <distributionManagement>
+    <site>
+      <id>gh-pages-scm</id>
+      <name>Mybatis GitHub Pages</name>
+      <url>scm:git:ssh://git@github.com/mybatis/generator.git</url>
+    </site>
+  </distributionManagement>
 
   <properties>
     <findbugs.onlyAnalyze>org.mybatis.generator.*</findbugs.onlyAnalyze>


### PR DESCRIPTION
While this site is multi module, we can continue using our parent hack otherwise for topSiteUrl as its only ran from one of the contained modules.  This change otherwise puts it in sync with others and to be on safe side, distro management is also put on the root module for clarity.