### PR TITLE
Properly Calculate Type Names when there are Wildcard Bounds

### DIFF
--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/FullyQualifiedJavaType.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/FullyQualifiedJavaType.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2006-2023 the original author or authors.
+ *    Copyright 2006-2025 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -87,21 +87,7 @@ public class FullyQualifiedJavaType implements Comparable<FullyQualifiedJavaType
      * @return Returns the fullyQualifiedName.
      */
     public String getFullyQualifiedName() {
-        StringBuilder sb = new StringBuilder();
-        if (wildcardType) {
-            sb.append('?');
-            if (boundedWildcard) {
-                if (extendsBoundedWildcard) {
-                    sb.append(" extends "); //$NON-NLS-1$
-                } else {
-                    sb.append(" super "); //$NON-NLS-1$
-                }
-
-                sb.append(baseQualifiedName);
-            }
-        } else {
-            sb.append(baseQualifiedName);
-        }
+        StringBuilder sb = new StringBuilder(getFullyQualifiedNameWithoutTypeParameters());
 
         if (!typeArguments.isEmpty()) {
             boolean first = true;
@@ -122,6 +108,30 @@ public class FullyQualifiedJavaType implements Comparable<FullyQualifiedJavaType
     }
 
     public String getFullyQualifiedNameWithoutTypeParameters() {
+        StringBuilder sb = new StringBuilder();
+        if (wildcardType) {
+            sb.append('?');
+            if (boundedWildcard) {
+                if (extendsBoundedWildcard) {
+                    sb.append(" extends "); //$NON-NLS-1$
+                } else {
+                    sb.append(" super "); //$NON-NLS-1$
+                }
+
+                sb.append(baseQualifiedName);
+            }
+        } else {
+            sb.append(baseQualifiedName);
+        }
+        return sb.toString();
+    }
+
+    /**
+     * The name (fully qualified) that should be imported
+     *
+     * @return the fully qualified name that should be imported. Does not include the wildcard bounds.
+     */
+    public String getImportName() {
         return baseQualifiedName;
     }
 
@@ -168,21 +178,7 @@ public class FullyQualifiedJavaType implements Comparable<FullyQualifiedJavaType
     }
 
     public String getShortName() {
-        StringBuilder sb = new StringBuilder();
-        if (wildcardType) {
-            sb.append('?');
-            if (boundedWildcard) {
-                if (extendsBoundedWildcard) {
-                    sb.append(" extends "); //$NON-NLS-1$
-                } else {
-                    sb.append(" super "); //$NON-NLS-1$
-                }
-
-                sb.append(baseShortName);
-            }
-        } else {
-            sb.append(baseShortName);
-        }
+        StringBuilder sb = new StringBuilder(getShortNameWithoutTypeArguments());
 
         if (!typeArguments.isEmpty()) {
             boolean first = true;
@@ -203,7 +199,22 @@ public class FullyQualifiedJavaType implements Comparable<FullyQualifiedJavaType
     }
 
     public String getShortNameWithoutTypeArguments() {
-        return baseShortName;
+        StringBuilder sb = new StringBuilder();
+        if (wildcardType) {
+            sb.append('?');
+            if (boundedWildcard) {
+                if (extendsBoundedWildcard) {
+                    sb.append(" extends "); //$NON-NLS-1$
+                } else {
+                    sb.append(" super "); //$NON-NLS-1$
+                }
+
+                sb.append(baseShortName);
+            }
+        } else {
+            sb.append(baseShortName);
+        }
+        return sb.toString();
     }
 
     @Override

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/JavaDomUtils.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/JavaDomUtils.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2006-2023 the original author or authors.
+ *    Copyright 2006-2025 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -81,7 +81,7 @@ public class JavaDomUtils {
 
     private static boolean typeIsAlreadyImported(CompilationUnit compilationUnit,
             FullyQualifiedJavaType fullyQualifiedJavaType) {
-        String name = fullyQualifiedJavaType.getFullyQualifiedNameWithoutTypeParameters();
+        String name = fullyQualifiedJavaType.getImportName();
         return compilationUnit.getImportedTypes().stream().anyMatch(e -> e.getImportList().contains(name));
     }
 }

--- a/core/mybatis-generator-core/src/test/java/org/mybatis/generator/api/dom/java/FullyQualifiedJavaTypeTest.java
+++ b/core/mybatis-generator-core/src/test/java/org/mybatis/generator/api/dom/java/FullyQualifiedJavaTypeTest.java
@@ -15,11 +15,13 @@
  */
 package org.mybatis.generator.api.dom.java;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
+import org.mybatis.generator.api.dom.java.render.TopLevelInterfaceRenderer;
 
 /**
  * @author Jeff Butler
@@ -268,5 +270,77 @@ class FullyQualifiedJavaTypeTest {
         assertTrue(fqjt.isArray());
         assertTrue(fqjt.getImportList().contains("java.util.List"));
         assertFalse(fqjt.getImportList().contains("java.util.List[]"));
+    }
+
+    @Test
+    void gh1288Test1() {
+        FullyQualifiedJavaType fqjt = new FullyQualifiedJavaType("Class<?>");
+        assertThat(fqjt.getFullyQualifiedName()).isEqualTo("Class<?>");
+
+        Method method = new Method("setConverter");
+        Parameter parameter = new Parameter(fqjt, "converterType");
+        method.addParameter(parameter);
+        method.setAbstract(true);
+
+        Interface interfaze = new Interface("foo.Bar");
+        interfaze.setVisibility(JavaVisibility.PUBLIC);
+        interfaze.addMethod(method);
+
+        TopLevelInterfaceRenderer renderer = new TopLevelInterfaceRenderer();
+        String out = renderer.render(interfaze);
+
+        assertThat(out).isEqualTo("package foo;\n\npublic interface Bar {\n    void setConverter(Class<?> converterType);\n}");
+    }
+
+    @Test
+    void gh1288Test2() {
+        FullyQualifiedJavaType fqjt = new FullyQualifiedJavaType("Class<? extends String>");
+        assertThat(fqjt.getFullyQualifiedName()).isEqualTo("Class<? extends String>");
+
+        Method method = new Method("setConverter");
+        Parameter parameter = new Parameter(fqjt, "converterType");
+        method.addParameter(parameter);
+        method.setAbstract(true);
+
+        Interface interfaze = new Interface("foo.Bar");
+        interfaze.setVisibility(JavaVisibility.PUBLIC);
+        interfaze.addMethod(method);
+
+        TopLevelInterfaceRenderer renderer = new TopLevelInterfaceRenderer();
+        String out = renderer.render(interfaze);
+
+        assertThat(out).isEqualTo("package foo;\n\npublic interface Bar {\n    void setConverter(Class<? extends String> converterType);\n}");
+    }
+
+    @Test
+    void gh1288Test3() {
+        FullyQualifiedJavaType fqjt = new FullyQualifiedJavaType("Class");
+        fqjt.addTypeArgument(new FullyQualifiedJavaType("? extends HttpMessageConverter<?>"));
+        assertThat(fqjt.getFullyQualifiedName()).isEqualTo("Class<? extends HttpMessageConverter<?>>");
+
+        Method method = new Method("setConverter");
+        Parameter parameter = new Parameter(fqjt, "converterType");
+        method.addParameter(parameter);
+        method.setAbstract(true);
+
+        Interface interfaze = new Interface("foo.Bar");
+        interfaze.setVisibility(JavaVisibility.PUBLIC);
+        interfaze.addMethod(method);
+
+        TopLevelInterfaceRenderer renderer = new TopLevelInterfaceRenderer();
+        String out = renderer.render(interfaze);
+
+        assertThat(out).isEqualTo("package foo;\n\npublic interface Bar {\n    void setConverter(Class<? extends HttpMessageConverter<?>> converterType);\n}");
+    }
+
+    @Test
+    void gh1288Test3Minified() {
+        FullyQualifiedJavaType fqjt = new FullyQualifiedJavaType("Class");
+        fqjt.addTypeArgument(new FullyQualifiedJavaType("? extends HttpMessageConverter<?>"));
+        assertThat(fqjt.getFullyQualifiedName()).isEqualTo("Class<? extends HttpMessageConverter<?>>");
+
+        Parameter parameter = new Parameter(fqjt, "converterType");
+        String out = parameter.toString();
+        assertThat(out).isEqualTo("Class<? extends HttpMessageConverter<?>> converterType");
     }
 }

--- a/core/mybatis-generator-core/src/test/java/org/mybatis/generator/api/dom/java/FullyQualifiedJavaTypeTest.java
+++ b/core/mybatis-generator-core/src/test/java/org/mybatis/generator/api/dom/java/FullyQualifiedJavaTypeTest.java
@@ -289,7 +289,7 @@ class FullyQualifiedJavaTypeTest {
         TopLevelInterfaceRenderer renderer = new TopLevelInterfaceRenderer();
         String out = renderer.render(interfaze);
 
-        assertThat(out).isEqualTo("package foo;\n\npublic interface Bar {\n    void setConverter(Class<?> converterType);\n}");
+        assertThat(out).isEqualToNormalizingNewlines("package foo;\n\npublic interface Bar {\n    void setConverter(Class<?> converterType);\n}");
     }
 
     @Test
@@ -309,7 +309,7 @@ class FullyQualifiedJavaTypeTest {
         TopLevelInterfaceRenderer renderer = new TopLevelInterfaceRenderer();
         String out = renderer.render(interfaze);
 
-        assertThat(out).isEqualTo("package foo;\n\npublic interface Bar {\n    void setConverter(Class<? extends String> converterType);\n}");
+        assertThat(out).isEqualToNormalizingNewlines("package foo;\n\npublic interface Bar {\n    void setConverter(Class<? extends String> converterType);\n}");
     }
 
     @Test
@@ -330,7 +330,7 @@ class FullyQualifiedJavaTypeTest {
         TopLevelInterfaceRenderer renderer = new TopLevelInterfaceRenderer();
         String out = renderer.render(interfaze);
 
-        assertThat(out).isEqualTo("package foo;\n\npublic interface Bar {\n    void setConverter(Class<? extends HttpMessageConverter<?>> converterType);\n}");
+        assertThat(out).isEqualToNormalizingNewlines("package foo;\n\npublic interface Bar {\n    void setConverter(Class<? extends HttpMessageConverter<?>> converterType);\n}");
     }
 
     @Test


### PR DESCRIPTION
The calculated type name should always include the wildcard bounds. But the wildcard bounds should not be used when calculating imports.

Resolves #1288 
