### PR TITLE
Align keyColumn support in <generatedKey> tag

### DIFF
--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/AbstractJavaMapperMethodGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/elements/AbstractJavaMapperMethodGenerator.java
@@ -40,6 +40,7 @@ import org.mybatis.generator.api.dom.java.Parameter;
 import org.mybatis.generator.codegen.AbstractGenerator;
 import org.mybatis.generator.codegen.mybatis3.ListUtilities;
 import org.mybatis.generator.config.GeneratedKey;
+import org.mybatis.generator.internal.util.StringUtility;
 
 public abstract class AbstractJavaMapperMethodGenerator extends AbstractGenerator {
     public abstract void addInterfaceElements(Interface interfaze);
@@ -97,7 +98,9 @@ public abstract class AbstractJavaMapperMethodGenerator extends AbstractGenerato
         if (gk.isJdbcStandard()) {
             sb.append("@Options(useGeneratedKeys=true,keyProperty=\""); //$NON-NLS-1$
             sb.append(introspectedColumn.getJavaProperty());
-            sb.append("\")"); //$NON-NLS-1$
+            sb.append("\""); //$NON-NLS-1$
+            sb.append(String.format(", keyColumn=\"%s\"", Optional.ofNullable(gk.getColumn()).map(StringUtility::escapeStringForJava).orElse(""))); //$NON-NLS-1$ $NON-NLS-2$
+            sb.append(")"); //$NON-NLS-1$
         } else {
             sb.append("@SelectKey(statement=\""); //$NON-NLS-1$
             sb.append(gk.getRuntimeSqlStatement());

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/elements/FragmentGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/elements/FragmentGenerator.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -32,6 +33,7 @@ import org.mybatis.generator.api.dom.java.Parameter;
 import org.mybatis.generator.codegen.mybatis3.ListUtilities;
 import org.mybatis.generator.config.GeneratedKey;
 import org.mybatis.generator.internal.util.JavaBeansUtil;
+import org.mybatis.generator.internal.util.StringUtility;
 
 public class FragmentGenerator {
 
@@ -246,7 +248,9 @@ public class FragmentGenerator {
                 builder.withImport(new FullyQualifiedJavaType("org.apache.ibatis.annotations.Options")); //$NON-NLS-1$
                 sb.append("@Options(useGeneratedKeys=true,keyProperty=\"row."); //$NON-NLS-1$
                 sb.append(introspectedColumn.getJavaProperty());
-                sb.append("\")"); //$NON-NLS-1$
+                sb.append("\""); //$NON-NLS-1$
+                sb.append(String.format(", keyColumn=\"%s\"", Optional.ofNullable(gk.getColumn()).map(StringUtility::escapeStringForJava).orElse(""))); //$NON-NLS-1$ $NON-NLS-2$
+                sb.append(")"); //$NON-NLS-1$
             } else {
                 builder.withImport(new FullyQualifiedJavaType("org.apache.ibatis.annotations.SelectKey")); //$NON-NLS-1$
                 FullyQualifiedJavaType fqjt = introspectedColumn.getFullyQualifiedJavaType();

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/kotlin/elements/KotlinFragmentGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/kotlin/elements/KotlinFragmentGenerator.java
@@ -22,6 +22,7 @@ import static org.mybatis.generator.internal.util.StringUtility.stringHasValue;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import org.mybatis.generator.api.IntrospectedColumn;
@@ -31,6 +32,7 @@ import org.mybatis.generator.api.dom.kotlin.JavaToKotlinTypeConverter;
 import org.mybatis.generator.api.dom.kotlin.KotlinArg;
 import org.mybatis.generator.codegen.mybatis3.ListUtilities;
 import org.mybatis.generator.config.GeneratedKey;
+import org.mybatis.generator.internal.util.StringUtility;
 import org.mybatis.generator.runtime.kotlin.KotlinDynamicSqlSupportClassGenerator;
 
 public class KotlinFragmentGenerator {
@@ -187,7 +189,9 @@ public class KotlinFragmentGenerator {
                 builder.withImport("org.apache.ibatis.annotations.Options"); //$NON-NLS-1$
                 sb.append("@Options(useGeneratedKeys=true,keyProperty=\"row."); //$NON-NLS-1$
                 sb.append(introspectedColumn.getJavaProperty());
-                sb.append("\")"); //$NON-NLS-1$
+                sb.append("\""); //$NON-NLS-1$
+                sb.append(String.format(", keyColumn=\"%s\"", Optional.ofNullable(gk.getColumn()).map(StringUtility::escapeStringForKotlin).orElse(""))); //$NON-NLS-1$ $NON-NLS-2$
+                sb.append(")"); //$NON-NLS-1$
                 builder.withAnnotation(sb.toString());
             } else {
                 builder.withImport("org.apache.ibatis.annotations.SelectKey"); //$NON-NLS-1$


### PR DESCRIPTION
Standardize keyColumn handling in the <generatedKey> tag for the following MyBatis Generator targets:

- KotlinMyBatis3Kotlin
- MyBatis3DynamicSql
- MyBatis3 ANNOTATEDMAPPER & MIXEDMAPPER

This update brings their behavior in line with the existing implementation in the MyBatis3 XMLMAPPER generator (refer to AbstractXmlElementGenerator::buildInitialInsert).