### PR TITLE
Feature Request : Configuration Change for Auto-generation Target Tables(with Postgres)

### DIFF
--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/plugins/SkipPartitionedWithPostgresTablesPlugin.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/plugins/SkipPartitionedWithPostgresTablesPlugin.java
@@ -1,0 +1,216 @@
+/*
+ *    Copyright 2006-2025 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.generator.plugins;
+
+import org.mybatis.generator.api.IntrospectedTable;
+import org.mybatis.generator.api.PluginAdapter;
+import org.mybatis.generator.api.dom.java.Interface;
+import org.mybatis.generator.api.dom.java.TopLevelClass;
+import org.mybatis.generator.config.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Properties;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * MBG plugin to skip generating artifacts for partitioned tables/views by using
+ * an allowlist file that contains non-partitioned table (and view) names.
+ * <p>
+ * Behavior:
+ * - Property "allowlistFile": path to a file to store allowed table names.
+ * The plugin will connect to the configured database and create (or overwrite) this file
+ * by listing non-partitioned tables/views (excluding 'pg_catalog' and 'information_schema' schemas).
+ * - If the allowlist could be loaded, generation occurs only for tables in the list.
+ * - If loading fails for any reason, the plugin will throw a RuntimeException (fail-fast).
+ */
+public class SkipPartitionedWithPostgresTablesPlugin extends PluginAdapter {
+
+    private Set<String> allowlist = null; // null until discovered
+    private boolean caseInsensitive = false;
+    private Set<String> allowlistNormalized = null; // used only when caseInsensitive
+
+    private boolean hasConnectionConfiguration() {
+        if (context == null) {
+            return false;
+        }
+
+        if (context.getConnectionFactoryConfiguration() != null) {
+            return true;
+        }
+
+        try {
+            Field f = Context.class.getDeclaredField("jdbcConnectionConfiguration");
+            f.setAccessible(true);
+            Object jdbcCfg = f.get(context);
+            return jdbcCfg != null;
+        } catch (Exception e) {
+            return true;
+        }
+    }
+
+    @Override
+    public void setProperties(Properties properties) {
+        super.setProperties(properties);
+
+        String ciProp = properties.getProperty("caseInsensitive");
+        if (ciProp != null && ciProp.equalsIgnoreCase("true")) {
+            caseInsensitive = true;
+        }
+
+        if (!hasConnectionConfiguration()) {
+            String msg = "No JDBC or ConnectionFactory configuration present - cannot discover non-partitioned tables for SkipPartitionedWithPostgresTablesPlugin";
+            throw new RuntimeException(msg);
+        }
+
+        try {
+            this.allowlist = discoverNonPartitionedTables();
+            if (caseInsensitive && allowlist != null) {
+                buildNormalizedAllowlist();
+            }
+        } catch (Exception e) { // fail-fast
+            throw new RuntimeException("Failed to discover non-partitioned tables/views", e);
+        }
+
+        String allowlistFilePath = properties.getProperty("allowlistFile", "");
+        if (allowlistFilePath != null && !allowlistFilePath.isEmpty() && allowlist != null) {
+            allowlistFilePath = allowlistFilePath.replace("/", File.separator);
+            Path output = Path.of(allowlistFilePath);
+            try {
+                Path parent = output.getParent();
+                if (parent != null) {
+                    Files.createDirectories(parent);
+                }
+                Files.write(output, new TreeSet<>(this.allowlist));
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to write allowlist file: " + output.toAbsolutePath(), e);
+            }
+        }
+    }
+
+    private void buildNormalizedAllowlist() {
+        if (allowlist != null) {
+            Set<String> normalized = new HashSet<>(allowlist.size());
+            for (String s : allowlist) {
+                if (s != null) {
+                    normalized.add(s.toLowerCase(Locale.ROOT));
+                }
+            }
+            this.allowlistNormalized = normalized;
+        }
+    }
+
+    @Override
+    public boolean validate(List<String> warnings) {
+        return true; // always valid
+    }
+
+    private Set<String> discoverNonPartitionedTables() throws SQLException {
+        final String query = "WITH partition_children AS (\n" +
+                "    SELECT\n" +
+                "        relname\n" +
+                "    FROM\n" +
+                "        pg_class\n" +
+                "            JOIN pg_inherits ON pg_class.oid = pg_inherits.inhrelid\n" +
+                ")\n" +
+                "\n" +
+                "SELECT\n" +
+                "    tablename\n" +
+                "FROM\n" +
+                "    pg_tables\n" +
+                "WHERE\n" +
+                "    schemaname NOT IN ('pg_catalog', 'information_schema')\n" +
+                "    AND tablename NOT IN (SELECT relname FROM partition_children)\n" +
+                "UNION ALL\n" +
+                "SELECT\n" +
+                "    viewname AS tablename\n" +
+                "FROM\n" +
+                "    pg_views\n" +
+                "WHERE\n" +
+                "    schemaname NOT IN ('pg_catalog', 'information_schema')\n" +
+                "ORDER BY\n" +
+                "    tablename\n";
+
+        Set<String> tables = new HashSet<>();
+        try (Connection conn = context.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(query);
+             ResultSet rs = stmt.executeQuery()) {
+            while (rs.next()) {
+                tables.add(rs.getString("tablename"));
+            }
+        }
+        return tables;
+    }
+
+    private boolean shouldSkip(IntrospectedTable introspectedTable) {
+        if (allowlist == null) {
+            return false; // If discovery failed we would have thrown; here null only before setProperties run in tests
+        }
+        String tableName = introspectedTable.getFullyQualifiedTable().getIntrospectedTableName();
+        boolean skip;
+        if (caseInsensitive) {
+            if (allowlistNormalized == null) { // lazy build if injected via reflection in tests
+                buildNormalizedAllowlist();
+            }
+            String key = tableName == null ? null : tableName.toLowerCase(Locale.ROOT);
+            skip = key == null || !allowlistNormalized.contains(key);
+        } else {
+            skip = !allowlist.contains(tableName);
+        }
+        return skip;
+    }
+
+    // Model generation hooks
+    @Override
+    public boolean modelBaseRecordClassGenerated(TopLevelClass topLevelClass, IntrospectedTable introspectedTable) {
+        return !shouldSkip(introspectedTable);
+    }
+
+    @Override
+    public boolean modelPrimaryKeyClassGenerated(TopLevelClass topLevelClass, IntrospectedTable introspectedTable) {
+        return !shouldSkip(introspectedTable);
+    }
+
+    @Override
+    public boolean modelRecordWithBLOBsClassGenerated(TopLevelClass topLevelClass, IntrospectedTable introspectedTable) {
+        return !shouldSkip(introspectedTable);
+    }
+
+    // Dynamic SQL support generation hook
+    @Override
+    public boolean dynamicSqlSupportGenerated(TopLevelClass topLevelClass, IntrospectedTable introspectedTable) {
+        return !shouldSkip(introspectedTable);
+    }
+
+    // Client (mapper) generation hooks
+    @Override
+    public boolean clientGenerated(Interface interfaze, IntrospectedTable introspectedTable) {
+        return !shouldSkip(introspectedTable);
+    }
+}

--- a/core/mybatis-generator-core/src/test/java/org/mybatis/generator/plugins/SkipPartitionedWithPostgresTablesPluginTest.java
+++ b/core/mybatis-generator-core/src/test/java/org/mybatis/generator/plugins/SkipPartitionedWithPostgresTablesPluginTest.java
@@ -1,0 +1,178 @@
+/*
+ *    Copyright 2006-2025 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.generator.plugins;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mybatis.generator.api.*;
+import org.mybatis.generator.api.dom.java.Interface;
+import org.mybatis.generator.api.dom.java.TopLevelClass;
+import org.mybatis.generator.config.Context;
+
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link SkipPartitionedWithPostgresTablesPlugin}.
+ *
+ * These tests focus on the decision logic that determines whether generation hooks
+ * should proceed based on the plugin's internal allowlist. We purposefully avoid
+ * calling {@link SkipPartitionedWithPostgresTablesPlugin#setProperties(java.util.Properties)}
+ * because that method attempts to connect to a PostgreSQL database using JDBC URLs
+ * and Postgres-specific catalog queries. Instead, we inject the allowlist directly
+ * via reflection so the tests remain fast and deterministic without external DB dependencies.
+ */
+class SkipPartitionedWithPostgresTablesPluginTest {
+
+    /**
+     * Simple IntrospectedTable stub that only supplies a table name.
+     */
+    private static class StubIntrospectedTable extends IntrospectedTable {
+        StubIntrospectedTable(String tableName) {
+            super(TargetRuntime.MYBATIS3);
+            // Create a minimal Context for FullyQualifiedTable (delimiters not used here)
+            Context ctx = new Context(null);
+            FullyQualifiedTable fqt = new FullyQualifiedTable(null, null, tableName, null, null,
+                    false, null, null, null, false, null, ctx);
+            setFullyQualifiedTable(fqt);
+        }
+        @Override public void calculateGenerators(List<String> warnings, ProgressCallback progressCallback) { }
+        @Override public List<GeneratedJavaFile> getGeneratedJavaFiles() { return Collections.emptyList(); }
+        @Override public List<GeneratedXmlFile> getGeneratedXmlFiles() { return Collections.emptyList(); }
+        @Override public List<GeneratedKotlinFile> getGeneratedKotlinFiles() { return Collections.emptyList(); }
+        @Override public int getGenerationSteps() { return 0; }
+        @Override public boolean requiresXMLGenerator() { return false; }
+    }
+
+    private SkipPartitionedWithPostgresTablesPlugin newPluginWithAllowlist(Set<String> allowlist) throws Exception {
+        SkipPartitionedWithPostgresTablesPlugin plugin = new SkipPartitionedWithPostgresTablesPlugin();
+        Field f = SkipPartitionedWithPostgresTablesPlugin.class.getDeclaredField("allowlist");
+        f.setAccessible(true);
+        f.set(plugin, allowlist);
+        return plugin;
+    }
+
+    private SkipPartitionedWithPostgresTablesPlugin newPluginWithAllowlistCaseInsensitive(Set<String> allowlist) throws Exception {
+        SkipPartitionedWithPostgresTablesPlugin plugin = newPluginWithAllowlist(allowlist);
+        Field ci = SkipPartitionedWithPostgresTablesPlugin.class.getDeclaredField("caseInsensitive");
+        ci.setAccessible(true);
+        ci.set(plugin, true);
+        // allowlistNormalized will be lazily built; ensure null now
+        Field norm = SkipPartitionedWithPostgresTablesPlugin.class.getDeclaredField("allowlistNormalized");
+        norm.setAccessible(true);
+        norm.set(plugin, null);
+        return plugin;
+    }
+
+    @Test
+    @DisplayName("When allowlist is null, plugin should NOT skip any table (fail-open)")
+    void testNoAllowlistDoesNotSkip() throws Exception {
+        SkipPartitionedWithPostgresTablesPlugin plugin = newPluginWithAllowlist(null);
+        boolean result = plugin.modelBaseRecordClassGenerated(new TopLevelClass("Dummy"), new StubIntrospectedTable("some_table"));
+        assertThat(result).as("Expect generation to proceed when allowlist is null").isTrue();
+    }
+
+    @Test
+    @DisplayName("Table present in allowlist should be generated (base record)")
+    void testAllowlistAllowsMatching() throws Exception {
+        SkipPartitionedWithPostgresTablesPlugin plugin = newPluginWithAllowlist(Set.of("customer"));
+        boolean result = plugin.modelBaseRecordClassGenerated(new TopLevelClass("Customer"), new StubIntrospectedTable("customer"));
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("Table NOT present in allowlist should be skipped (base record)")
+    void testAllowlistSkipsNonMatching() throws Exception {
+        SkipPartitionedWithPostgresTablesPlugin plugin = newPluginWithAllowlist(Set.of("customer"));
+        boolean result = plugin.modelBaseRecordClassGenerated(new TopLevelClass("Order"), new StubIntrospectedTable("orders"));
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("Case sensitivity: exact match required (mismatch should skip)")
+    void testCaseSensitivity() throws Exception {
+        SkipPartitionedWithPostgresTablesPlugin plugin = newPluginWithAllowlist(Set.of("Customer"));
+        // underlying table name is lowercase 'customer' which does not equal 'Customer'
+        boolean result = plugin.modelBaseRecordClassGenerated(new TopLevelClass("Customer"), new StubIntrospectedTable("customer"));
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("Case insensitive: allowlist 'Customer' matches table 'customer' when caseInsensitive=true")
+    void testCaseInsensitiveAllowsLowerCase() throws Exception {
+        SkipPartitionedWithPostgresTablesPlugin plugin = newPluginWithAllowlistCaseInsensitive(Set.of("Customer"));
+        boolean result = plugin.modelBaseRecordClassGenerated(new TopLevelClass("Customer"), new StubIntrospectedTable("customer"));
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("Case insensitive: non-matching table still skipped when caseInsensitive=true")
+    void testCaseInsensitiveSkipsMissing() throws Exception {
+        SkipPartitionedWithPostgresTablesPlugin plugin = newPluginWithAllowlistCaseInsensitive(Set.of("Alpha", "Beta"));
+        boolean result = plugin.modelBaseRecordClassGenerated(new TopLevelClass("Gamma"), new StubIntrospectedTable("gAmMa"));
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("All generation hook methods behave consistently with allowlist")
+    void testOtherHooksConsistency() throws Exception {
+        SkipPartitionedWithPostgresTablesPlugin plugin = newPluginWithAllowlist(Set.of("alpha", "beta"));
+        StubIntrospectedTable allowed = new StubIntrospectedTable("alpha");
+        StubIntrospectedTable disallowed = new StubIntrospectedTable("gamma");
+
+        TopLevelClass tlc = new TopLevelClass("Alpha");
+        Interface iface = new Interface("AlphaMapper");
+
+        // Allowed table
+        assertThat(plugin.modelPrimaryKeyClassGenerated(tlc, allowed)).isTrue();
+        assertThat(plugin.modelRecordWithBLOBsClassGenerated(tlc, allowed)).isTrue();
+        assertThat(plugin.dynamicSqlSupportGenerated(tlc, allowed)).isTrue();
+        assertThat(plugin.clientGenerated(iface, allowed)).isTrue();
+
+        // Disallowed table
+        assertThat(plugin.modelPrimaryKeyClassGenerated(tlc, disallowed)).isFalse();
+        assertThat(plugin.modelRecordWithBLOBsClassGenerated(tlc, disallowed)).isFalse();
+        assertThat(plugin.dynamicSqlSupportGenerated(tlc, disallowed)).isFalse();
+        assertThat(plugin.clientGenerated(iface, disallowed)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Fail-fast: JDBC 未設定 + allowlistFile 指定時は 事前チェックメッセージで RuntimeException")
+    void testSetPropertiesWithoutJdbcConfig() throws Exception {
+        SkipPartitionedWithPostgresTablesPlugin plugin = new SkipPartitionedWithPostgresTablesPlugin();
+        Context ctx = new Context(null); // JDBC 設定なし
+        plugin.setContext(ctx);
+        Path tempDir = Files.createTempDirectory("mbg-test");
+        Path allowlistFile = tempDir.resolve("allowlist-generated.txt");
+        Properties props = new Properties();
+        props.setProperty("allowlistFile", allowlistFile.toString());
+
+        assertThatThrownBy(() -> plugin.setProperties(props))
+                .as("事前チェックで JDBC/ConnectionFactory 未設定エラーが出る")
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("No JDBC or ConnectionFactory configuration present");
+
+        assertThat(Files.exists(allowlistFile)).as("例外発生時は allowlist ファイルは生成されない").isFalse();
+    }
+}


### PR DESCRIPTION
# Description

Adds SkipPartitionedWithPostgresTablesPlugin, a MyBatis Generator (MBG) plugin that skips generating artifacts (model classes, mappers, dynamic SQL support) for PostgreSQL partition child tables. It discovers all non-partition-child tables plus views (excluding pg_catalog and information_schema) and only generates code for those. Optionally writes the allowlist to a file. Supports case-insensitive matching.

# Background

PostgreSQL declarative partitioning creates a physical table for every partition. Generating MyBatis artifacts for each child partition leads to:
 - A large number of nearly identical classes/mappers
 - Churn when time-based partitions rotate
 - Redundant code when logic works at the parent level or routing is external

This plugin:

 - Queries PostgreSQL system catalogs (pg_inherits, pg_class, pg_tables, pg_views)
 - Excludes partition child tables
 - Keeps normal tables, partition parent tables, and views
 - Fails fast (throws RuntimeException) if discovery or writing the allowlist fails

# Usage
Add the plugin inside an MBG <context> that has a PostgreSQL connection (either jdbcConnection or connectionFactory).

 - Available properties:
   - allowlistFile (optional): file path to write the discovered (sorted) table/view names
   - caseInsensitive (optional, default false): perform case-insensitive matching

Example:
```xml
<context id="PostgresContext" targetRuntime="MyBatis3">
  <jdbcConnection driverClass="org.postgresql.Driver"
                  connectionURL="jdbc:postgresql://localhost:5432/appdb"
                  userId="app"
                  password="secret"/>

  <plugin type="org.mybatis.generator.plugins.SkipPartitionedWithPostgresTablesPlugin">
    <property name="allowlistFile" value="build/mbg/allowlist.txt"/>
    <property name="caseInsensitive" value="true"/>
  </plugin>

  <!-- Optional <table> elements. If omitted, MBG introspects all; the plugin filters afterward. -->
</context>
```

# Behavior summary:
 - Discovers non-partition-child tables (excludes system schemas)
 - Adds views (non-system schemas)
 - Builds in-memory allowlist (+ optional file write) - 
 - Skips generation for anything not in the allowlist
 - Runtime exception on any discovery or write failure

# Limitations / Notes:
 - Partition parent tables are still included
 - No custom schema include/exclude yet (only system schemas excluded)
