### PR TITLE
Generic Support for javaClientGenerator

### DIFF
--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/AbstractJavaClientGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/AbstractJavaClientGenerator.java
@@ -15,6 +15,8 @@
  */
 package org.mybatis.generator.codegen;
 
+import static org.mybatis.generator.internal.util.StringUtility.stringHasValue;
+
 /**
  * This class exists to that Java client generators can specify whether
  * an XML generator is required to match the methods in the
@@ -49,4 +51,92 @@ public abstract class AbstractJavaClientGenerator extends AbstractJavaGenerator 
      *     XML is required by this generator
      */
     public abstract AbstractXmlGenerator getMatchedXMLGenerator();
+
+    /**
+     * Processes the rootInterface string to replace generic type placeholders with the actual record type.
+     * <p>
+     * If the rootInterface contains a generic placeholder like {@code <T>}, {@code <E>}, etc., it will be
+     * replaced with the actual record type from the introspected table. For example:
+     * <ul>
+     *   <li>{@code "BaseMapper<T>"} becomes {@code "BaseMapper<com.example.User>"}</li>
+     *   <li>{@code "BaseMapper"} remains {@code "BaseMapper"} (no change for backward compatibility)</li>
+     *   <li>{@code "BaseMapper<com.example.User>"} remains unchanged (already fully qualified)</li>
+     * </ul>
+     *
+     * @param rootInterface
+     *            the rootInterface string from configuration, may contain generic placeholders
+     * @param recordType
+     *            the actual record type (fully qualified) to use as replacement
+     * @return the processed rootInterface string with placeholders replaced, or the original string if no
+     *         replacement is needed
+     */
+    protected String processRootInterfaceWithGenerics(String rootInterface, String recordType) {
+        if (!stringHasValue(rootInterface) || !stringHasValue(recordType)) {
+            return rootInterface;
+        }
+
+        // Check if rootInterface contains generic brackets
+        int openBracketIndex = rootInterface.indexOf('<');
+        if (openBracketIndex == -1) {
+            // No generic brackets, return as-is for backward compatibility
+            return rootInterface;
+        }
+
+        int closeBracketIndex = rootInterface.lastIndexOf('>');
+        if (closeBracketIndex == -1 || closeBracketIndex <= openBracketIndex) {
+            // Malformed generic brackets, return as-is
+            return rootInterface;
+        }
+
+        String baseInterface = rootInterface.substring(0, openBracketIndex);
+        String genericContent = rootInterface.substring(openBracketIndex + 1, closeBracketIndex).trim();
+
+        // Check if the generic content is a placeholder (single letter or single letter with extends clause)
+        // Common Java generic type parameter names: T, E, K, V, N, U, R, S
+        if (isGenericPlaceholder(genericContent)) {
+            // Replace placeholder with actual record type
+            return baseInterface + "<" + recordType + ">";
+        }
+
+        // Already has a concrete type (fully qualified or not), return as-is
+        return rootInterface;
+    }
+
+    /**
+     * Checks if a generic content string represents a placeholder that should be replaced.
+     * Placeholders are typically single-letter type parameters like T, E, K, V, etc.,
+     * optionally with an "extends" clause like "T extends Entity".
+     *
+     * @param genericContent
+     *            the content between angle brackets
+     * @return true if this looks like a placeholder that should be replaced
+     */
+    private boolean isGenericPlaceholder(String genericContent) {
+        if (genericContent.isEmpty()) {
+            return false;
+        }
+
+        String trimmed = genericContent.trim();
+        
+        // Simple case: just a single uppercase letter (T, E, K, V, etc.)
+        if (trimmed.length() == 1 && Character.isUpperCase(trimmed.charAt(0))) {
+            return true;
+        }
+
+        // Case with bounds: "T extends SomeClass" or "T super SomeClass"
+        // Pattern: single uppercase letter followed by " extends " or " super "
+        int extendsIndex = trimmed.indexOf(" extends ");
+        int superIndex = trimmed.indexOf(" super ");
+        
+        if (extendsIndex > 0 || superIndex > 0) {
+            int boundIndex = extendsIndex > 0 ? extendsIndex : superIndex;
+            // First part should be a single uppercase letter
+            String typeParam = trimmed.substring(0, boundIndex).trim();
+            if (typeParam.length() == 1 && Character.isUpperCase(typeParam.charAt(0))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/JavaMapperGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/JavaMapperGenerator.java
@@ -75,7 +75,10 @@ public class JavaMapperGenerator extends AbstractJavaClientGenerator {
         }
 
         if (stringHasValue(rootInterface)) {
-            FullyQualifiedJavaType fqjt = new FullyQualifiedJavaType(rootInterface);
+            // Process rootInterface to replace generic placeholders with actual record type
+            String recordType = introspectedTable.getBaseRecordType();
+            String processedRootInterface = processRootInterfaceWithGenerics(rootInterface, recordType);
+            FullyQualifiedJavaType fqjt = new FullyQualifiedJavaType(processedRootInterface);
             interfaze.addSuperInterface(fqjt);
             interfaze.addImportedType(fqjt);
         }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/SimpleJavaClientGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/mybatis3/javamapper/SimpleJavaClientGenerator.java
@@ -66,7 +66,10 @@ public class SimpleJavaClientGenerator extends AbstractJavaClientGenerator {
         }
 
         if (stringHasValue(rootInterface)) {
-            FullyQualifiedJavaType fqjt = new FullyQualifiedJavaType(rootInterface);
+            // Process rootInterface to replace generic placeholders with actual record type
+            String recordType = introspectedTable.getBaseRecordType();
+            String processedRootInterface = processRootInterfaceWithGenerics(rootInterface, recordType);
+            FullyQualifiedJavaType fqjt = new FullyQualifiedJavaType(processedRootInterface);
             interfaze.addSuperInterface(fqjt);
             interfaze.addImportedType(fqjt);
         }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/DynamicSqlMapperGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/runtime/dynamic/sql/DynamicSqlMapperGenerator.java
@@ -155,7 +155,10 @@ public class DynamicSqlMapperGenerator extends AbstractJavaClientGenerator {
         }
 
         if (stringHasValue(rootInterface)) {
-            FullyQualifiedJavaType fqjt = new FullyQualifiedJavaType(rootInterface);
+            // Process rootInterface to replace generic placeholders with actual record type
+            String processedRootInterface = processRootInterfaceWithGenerics(rootInterface,
+                    recordType.getFullyQualifiedName());
+            FullyQualifiedJavaType fqjt = new FullyQualifiedJavaType(processedRootInterface);
             interfaze.addSuperInterface(fqjt);
             interfaze.addImportedType(fqjt);
         }

--- a/core/mybatis-generator-core/src/site/xhtml/configreference/javaClientGenerator.xhtml
+++ b/core/mybatis-generator-core/src/site/xhtml/configreference/javaClientGenerator.xhtml
@@ -169,7 +169,20 @@ specified with the <a href="property.html">&lt;property&gt;</a> child element:</
       <p><b>Important:</b> MBG does not verify that the interface exists, or is a
        valid Java interface.</p>
       <p>If specified, the value of this property should be a fully qualified
-       interface name (like com.mycompany.MyRootInterface).</p></td>
+       interface name (like com.mycompany.MyRootInterface).</p>
+      <p><b>Generic Type Support:</b> If the root interface is a generic interface, you can
+       use a placeholder for the type parameter. The placeholder will be automatically
+       replaced with the actual record type for each table. For example:
+       <ul>
+         <li><code>com.mycompany.BaseMapper&lt;T&gt;</code> will become
+             <code>com.mycompany.BaseMapper&lt;com.example.User&gt;</code> for a User table</li>
+         <li><code>com.mycompany.BaseMapper&lt;T extends Entity&gt;</code> will become
+             <code>com.mycompany.BaseMapper&lt;com.example.User&gt;</code></li>
+       </ul>
+       Placeholders are typically single uppercase letters (T, E, K, V, etc.) optionally
+       followed by " extends ..." or " super ...". If you specify a fully qualified type
+       (like <code>BaseMapper&lt;com.example.User&gt;</code>), it will be used as-is without
+       replacement.</p></td>
   </tr>
 </table>
 

--- a/core/mybatis-generator-core/src/site/xhtml/configreference/table.xhtml
+++ b/core/mybatis-generator-core/src/site/xhtml/configreference/table.xhtml
@@ -416,7 +416,20 @@ specified with the <a href="property.html">&lt;property&gt;</a> child element:</
       <p><b>Important:</b> MBG does not verify that the interface exists, or is a
        valid Java interface.</p>
       <p>If specified, the value of this property should be a fully qualified
-       interface name (like com.mycompany.MyRootInterface).</p></td>
+       interface name (like com.mycompany.MyRootInterface).</p>
+      <p><b>Generic Type Support:</b> If the root interface is a generic interface, you can
+       use a placeholder for the type parameter. The placeholder will be automatically
+       replaced with the actual record type for this table. For example:
+       <ul>
+         <li><code>com.mycompany.BaseMapper&lt;T&gt;</code> will become
+             <code>com.mycompany.BaseMapper&lt;com.example.User&gt;</code></li>
+         <li><code>com.mycompany.BaseMapper&lt;T extends Entity&gt;</code> will become
+             <code>com.mycompany.BaseMapper&lt;com.example.User&gt;</code></li>
+       </ul>
+       Placeholders are typically single uppercase letters (T, E, K, V, etc.) optionally
+       followed by " extends ..." or " super ...". If you specify a fully qualified type
+       (like <code>BaseMapper&lt;com.example.User&gt;</code>), it will be used as-is without
+       replacement.</p></td>
   </tr>
   <tr>
     <td valign="top">runtimeCatalog</td>


### PR DESCRIPTION
## Summary
Implemented generic type support for the `rootInterface` property in MyBatis Generator, addressing issue https://github.com/mybatis/generator/issues/1346.

## Changes Made:

1. Added utility method in `AbstractJavaClientGenerator`:

    - `processRootInterfaceWithGenerics()`: Processes the rootInterface string and replaces generic placeholders (e.g., `<T>`, `<T extends Entity>`) with the actual record type from the introspected table
    
    - `isGenericPlaceholder()`: Detects if the generic content is a placeholder (single uppercase letter like T, E, K, V, optionally with "extends" or "super" clause)

2. Updated all three Java client generators:

    - `JavaMapperGenerator`
    
    - `SimpleJavaClientGenerator`
    
    - `DynamicSqlMapperGenerator`

3. Updated documentation:

    - Added "Generic Type Support" section to both `javaClientGenerator.xhtml` and `table.xhtml` documentation files

4. How It Works:

    - If you specify `rootInterface="BaseMapper<T>"`, it becomes `BaseMapper<com.example.User>` for a User table
    - If you specify `rootInterface="BaseMapper<T extends Entity>"`, it becomes `BaseMapper<com.example.User>`
    - If you specify `rootInterface="BaseMapper"` (no generics), it remains unchanged (backward compatible)
    - If you specify `rootInterface="BaseMapper<com.example.User>"` (fully qualified), it's used as-is

## Example Usage:
```xml
<javaClientGenerator targetPackage="com.example.mapper" targetProject="src/main/java" type="XMLMAPPER">
    <property name="rootInterface" value="com.mycompany.BaseMapper&lt;T&gt;"/>
</javaClientGenerator>
```
This will generate mapper interfaces like:
```java
public interface UserMapper extends BaseMapper<User> {
    // ...
}
```

## Resolves
Closes https://github.com/mybatis/generator/issues/1346 - Feature Request : Generics support in javaClientGenerator rootInterface

<br/>


The implementation is backward compatible and passes all linter checks.
Ready for testing and review.

Contribution by Gittensor, learn more at https://gittensor.io/
