### PR TITLE
The Plugin "initialized" Method is Called Too Early

### DIFF
--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/IntrospectedTable.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/IntrospectedTable.java
@@ -24,7 +24,6 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 
 import org.jspecify.annotations.Nullable;
-import org.mybatis.generator.internal.PluginAggregator;
 import org.mybatis.generator.internal.rules.ConditionalModelRules;
 import org.mybatis.generator.internal.rules.FlatModelRules;
 import org.mybatis.generator.internal.rules.HierarchicalModelRules;
@@ -56,8 +55,6 @@ public class IntrospectedTable extends CodeGenerationAttributes {
 
     protected IntrospectedTable(Builder builder) {
         super(builder);
-        Objects.requireNonNull(builder.pluginAggregator);
-        builder.pluginAggregator.initialized(this);
     }
 
     public Optional<IntrospectedColumn> getColumn(String columnName) {
@@ -239,13 +236,6 @@ public class IntrospectedTable extends CodeGenerationAttributes {
     }
 
     public static class Builder extends AbstractBuilder<Builder> {
-        private @Nullable PluginAggregator pluginAggregator;
-
-        public Builder withPluginAggregator(PluginAggregator pluginAggregator) {
-            this.pluginAggregator = pluginAggregator;
-            return this;
-        }
-
         public IntrospectedTable build() {
             return new IntrospectedTable(this);
         }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/MyBatisGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/MyBatisGenerator.java
@@ -226,13 +226,17 @@ public class MyBatisGenerator {
                                                             CalculatedContextValues contextValues,
                                                             List<String> warnings)
             throws SQLException, InterruptedException {
-        return new IntrospectionEngine.Builder()
+        List<IntrospectedTable> answer = new IntrospectionEngine.Builder()
                 .withContextValues(contextValues)
                 .withFullyQualifiedTableNames(fullyQualifiedTableNames)
                 .withWarnings(warnings)
                 .withProgressCallback(progressCallback)
                 .build()
                 .introspectTables();
+
+        answer.forEach(t -> contextValues.pluginAggregator().initialized(t));
+
+        return answer;
     }
 
     private List<GenerationEngine> createGenerationEngines(List<ContextValuesAndTables> contextValuesAndTablesListList,

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/render/AbstractJavaRenderer.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/dom/java/render/AbstractJavaRenderer.java
@@ -150,7 +150,8 @@ public abstract class AbstractJavaRenderer {
     }
 
     private Stream<String> renderInnerRecord(InnerRecord innerRecord, CompilationUnit compilationUnit) {
-        innerRecordRenderer = Objects.requireNonNullElseGet(innerRecordRenderer, () -> new InnerRecordRenderer(indenter));
+        innerRecordRenderer =
+                Objects.requireNonNullElseGet(innerRecordRenderer, () -> new InnerRecordRenderer(indenter));
         return addEmptyLine(innerRecordRenderer.render(innerRecord, compilationUnit).stream()
                 .map(this::javaIndent));
     }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/IntrospectionEngine.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/codegen/IntrospectionEngine.java
@@ -78,7 +78,7 @@ public class IntrospectionEngine {
 
                 progressCallback.startTask(getString("Progress.1", tc.getFullyQualifiedName())); //$NON-NLS-1$
                 List<IntrospectedTable> tables = databaseIntrospector
-                        .introspectTables(tc, contextValues.knownRuntime(), contextValues.pluginAggregator());
+                        .introspectTables(tc, contextValues.knownRuntime());
                 introspectedTables.addAll(tables);
 
                 progressCallback.checkCancel();

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/internal/db/DatabaseIntrospector.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/internal/db/DatabaseIntrospector.java
@@ -51,7 +51,6 @@ import org.mybatis.generator.config.GeneratedKey;
 import org.mybatis.generator.config.PropertyRegistry;
 import org.mybatis.generator.config.TableConfiguration;
 import org.mybatis.generator.internal.ObjectFactory;
-import org.mybatis.generator.internal.PluginAggregator;
 import org.mybatis.generator.internal.util.JavaBeansUtil;
 
 public class DatabaseIntrospector {
@@ -136,8 +135,8 @@ public class DatabaseIntrospector {
      * @throws SQLException
      *             if any errors in introspection
      */
-    public List<IntrospectedTable> introspectTables(TableConfiguration tc, KnownRuntime knownRuntime,
-                                                    PluginAggregator pluginAggregator) throws SQLException {
+    public List<IntrospectedTable> introspectTables(TableConfiguration tc, KnownRuntime knownRuntime)
+            throws SQLException {
         // get the raw columns from the DB
         Map<ActualTableName, List<IntrospectedColumn>> columns = getColumns(tc);
 
@@ -154,8 +153,7 @@ public class DatabaseIntrospector {
         applyColumnOverrides(tc, columns);
         calculateIdentityColumns(tc, columns);
 
-        List<IntrospectedTable> introspectedTables =
-                calculateIntrospectedTables(tc, columns, knownRuntime, pluginAggregator);
+        List<IntrospectedTable> introspectedTables = calculateIntrospectedTables(tc, columns, knownRuntime);
 
         // now introspectedTables has all the columns from all the
         // tables in the configuration. Do some validation...
@@ -464,7 +462,7 @@ public class DatabaseIntrospector {
     }
 
     private List<IntrospectedTable> calculateIntrospectedTables(TableConfiguration tc, Map<ActualTableName,
-            List<IntrospectedColumn>> columns, KnownRuntime knownRuntime, PluginAggregator pluginAggregator) {
+            List<IntrospectedColumn>> columns, KnownRuntime knownRuntime) {
         boolean delimitIdentifiers = tc.isDelimitIdentifiers()
                 || stringContainsSpace(tc.getCatalog())
                 || stringContainsSpace(tc.getSchema())
@@ -503,7 +501,6 @@ public class DatabaseIntrospector {
                     .withFullyQualifiedTable(table)
                     .withContext(context)
                     .withKnownRuntime(knownRuntime)
-                    .withPluginAggregator(pluginAggregator)
                     .build();
 
             for (IntrospectedColumn introspectedColumn : entry.getValue()) {

--- a/core/mybatis-generator-core/src/site/xhtml/whatsNew.xhtml
+++ b/core/mybatis-generator-core/src/site/xhtml/whatsNew.xhtml
@@ -28,8 +28,11 @@
 <h2>Version 2.1.0</h2>
 <p>This is a minor release for the generator with the following updates:</p>
 <ul>
-  <li>Indentation specifications for generated code can now be configured. See the
+  <li>Enhancement - Indentation specifications for generated code can now be configured. See the
     <a href="configreference/indentation.html">Indentation Configuration Page</a> for further details.
+  </li>
+  <li>Bug Fix – The plugin "initialized" method was being called too early – before the IntrospectedTable was completely
+    initialized. This would break plugins that relied on the IntrospectedTable being fully initialized.
   </li>
 </ul>
 

--- a/core/mybatis-generator-core/src/test/java/org/mybatis/generator/api/CodeGenerationAttributesTest.java
+++ b/core/mybatis-generator-core/src/test/java/org/mybatis/generator/api/CodeGenerationAttributesTest.java
@@ -25,7 +25,6 @@ import org.mybatis.generator.config.ModelGeneratorConfiguration;
 import org.mybatis.generator.config.SqlMapGeneratorConfiguration;
 import org.mybatis.generator.config.TableConfiguration;
 import org.mybatis.generator.exception.InternalException;
-import org.mybatis.generator.internal.PluginAggregator;
 import org.mybatis.generator.internal.rules.ConditionalModelRules;
 import org.mybatis.generator.internal.rules.FlatModelRules;
 
@@ -436,7 +435,6 @@ class CodeGenerationAttributesTest {
 
         return new IntrospectedTable.Builder()
                 .withContext(context)
-                .withPluginAggregator(new PluginAggregator())
                 .withKnownRuntime(KnownRuntime.MYBATIS3)
                 .withFullyQualifiedTable(fullyQualifiedTable)
                 .withTableConfiguration(tableConfiguration)
@@ -471,7 +469,6 @@ class CodeGenerationAttributesTest {
 
         return new IntrospectedTable.Builder()
                 .withContext(context)
-                .withPluginAggregator(new PluginAggregator())
                 .withKnownRuntime(KnownRuntime.MYBATIS3)
                 .withFullyQualifiedTable(fullyQualifiedTable)
                 .withTableConfiguration(tableConfiguration)
@@ -512,7 +509,6 @@ class CodeGenerationAttributesTest {
 
         return new IntrospectedTable.Builder()
                 .withContext(context)
-                .withPluginAggregator(new PluginAggregator())
                 .withKnownRuntime(KnownRuntime.MYBATIS3)
                 .withFullyQualifiedTable(fullyQualifiedTable)
                 .withTableConfiguration(tableConfiguration)

--- a/core/mybatis-generator-core/src/test/java/org/mybatis/generator/internal/DefaultCommentGeneratorTest.java
+++ b/core/mybatis-generator-core/src/test/java/org/mybatis/generator/internal/DefaultCommentGeneratorTest.java
@@ -163,7 +163,6 @@ class DefaultCommentGeneratorTest {
                                 .withTargetProject("test-project")
                                 .build())
                         .build())
-                .withPluginAggregator(new PluginAggregator())
                 .build();
         answer.setRemarks("Database table remarks");
 

--- a/core/mybatis-generator-core/src/test/resources/scripts/CreateDB.sql
+++ b/core/mybatis-generator-core/src/test/resources/scripts/CreateDB.sql
@@ -38,6 +38,7 @@ drop sequence TestSequence if exists;
 drop table suffix_rename if exists;
 drop table Person if exists;
 drop table Address if exists;
+drop table VirtualPrimaryKey if exists;
 
 create sequence TestSequence as integer start with 1;
 
@@ -243,3 +244,7 @@ create table Address (
   primary key(id)
 );
 
+create table VirtualPrimaryKey (
+  id int not null,
+  description varchar(30)
+);

--- a/core/mybatis-generator-core/src/test/resources/scripts/generatorConfig_Dsql.xml
+++ b/core/mybatis-generator-core/src/test/resources/scripts/generatorConfig_Dsql.xml
@@ -26,6 +26,7 @@
     <plugin type="org.mybatis.generator.plugins.RecordWithMethodsPlugin" >
         <property name="fieldCountTrigger" value="2"/>
     </plugin>
+    <plugin type="org.mybatis.generator.plugins.VirtualPrimaryKeyPlugin" />
 
     <jdbcConnection driverClass="org.hsqldb.jdbcDriver"
         connectionURL="jdbc:hsqldb:mem:aname"
@@ -75,6 +76,9 @@
     <table schema="mbgtest" tableName="Ids" domainObjectName="Id" modelType="record">
       <property name="dynamicSqlSupportClassName" value="sub.IdDSQLSupport"/>
       <property name="useSnakeCaseIdentifiers" value="true"/>
+    </table>
+    <table tableName="VirtualPrimaryKey">
+      <property name="virtualKeyColumns" value="ID" />
     </table>
   </context>
 

--- a/core/mybatis-generator-systests-common/src/main/resources/mbg/test/common/scripts/CreateDB.sql
+++ b/core/mybatis-generator-systests-common/src/main/resources/mbg/test/common/scripts/CreateDB.sql
@@ -38,6 +38,7 @@ drop sequence TestSequence if exists;
 drop table suffix_rename if exists;
 drop table Person if exists;
 drop table Address if exists;
+drop table VirtualPrimaryKey if exists;
 
 create sequence TestSequence as integer start with 1;
 
@@ -243,3 +244,7 @@ create table Address (
   primary key(id)
 );
 
+create table VirtualPrimaryKey (
+  id int not null,
+  description varchar(30)
+);

--- a/core/mybatis-generator-systests-mybatis3-java8/src/main/resources/generatorConfig.xml
+++ b/core/mybatis-generator-systests-mybatis3-java8/src/main/resources/generatorConfig.xml
@@ -26,6 +26,7 @@
     <plugin type="org.mybatis.generator.plugins.RecordWithMethodsPlugin" >
         <property name="fieldCountTrigger" value="2"/>
     </plugin>
+    <plugin type="org.mybatis.generator.plugins.VirtualPrimaryKeyPlugin" />
 
     <jdbcConnection driverClass="org.hsqldb.jdbcDriver"
         connectionURL="jdbc:hsqldb:mem:aname"
@@ -75,6 +76,9 @@
     <table schema="mbgtest" tableName="Ids" domainObjectName="Id" modelType="record">
       <property name="dynamicSqlSupportClassName" value="sub.IdDSQLSupport"/>
       <property name="useSnakeCaseIdentifiers" value="true"/>
+    </table>
+    <table tableName="VirtualPrimaryKey">
+      <property name="virtualKeyColumns" value="ID" />
     </table>
   </context>
 

--- a/core/mybatis-generator-systests-mybatis3-java8/src/test/java/mbg/test/mb3/dsql/AbstractTest.java
+++ b/core/mybatis-generator-systests-mybatis3-java8/src/test/java/mbg/test/mb3/dsql/AbstractTest.java
@@ -17,6 +17,7 @@ package mbg.test.mb3.dsql;
 
 import static mbg.test.common.util.TestUtilities.createDatabase;
 
+import mbg.test.mb3.generated.dsql.mapper.VirtualprimarykeyMapper;
 import org.apache.ibatis.datasource.unpooled.UnpooledDataSource;
 import org.apache.ibatis.mapping.Environment;
 import org.apache.ibatis.session.Configuration;
@@ -61,6 +62,7 @@ public abstract class AbstractTest {
         config.addMapper(PkonlyMapper.class);
         config.addMapper(TranslationMapper.class);
         config.addMapper(IdMapper.class);
+        config.addMapper(VirtualprimarykeyMapper.class);
         sqlSessionFactory = new SqlSessionFactoryBuilder().build(config);
     }
 }

--- a/core/mybatis-generator-systests-mybatis3-java8/src/test/java/mbg/test/mb3/dsql/DynamicSqlTest.java
+++ b/core/mybatis-generator-systests-mybatis3-java8/src/test/java/mbg/test/mb3/dsql/DynamicSqlTest.java
@@ -40,6 +40,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
+import mbg.test.mb3.generated.dsql.mapper.VirtualprimarykeyMapper;
+import mbg.test.mb3.generated.dsql.model.Virtualprimarykey;
 import org.apache.ibatis.session.SqlSession;
 import org.junit.jupiter.api.Test;
 
@@ -3080,6 +3082,23 @@ public class DynamicSqlTest extends AbstractTest {
 
             List<Id> allIds = mapper.select(SelectDSLCompleter.allRows());
             assertThat(allIds).containsExactlyInAnyOrder(idSpanish, idItalian);
+        }
+    }
+
+    @Test
+    public void testVirtualPrimaryKey() {
+        try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+            VirtualprimarykeyMapper mapper = sqlSession.getMapper(VirtualprimarykeyMapper.class);
+            Virtualprimarykey record = new Virtualprimarykey();
+            record.setId(1);
+            record.setDescription("Description");
+            mapper.insert(record);
+
+            Optional<Virtualprimarykey> returnedRecord = mapper.selectByPrimaryKey(1);
+            assertThat(returnedRecord).hasValueSatisfying(rr -> {
+                assertThat(rr).hasFieldOrPropertyWithValue("id", 1);
+                assertThat(rr).hasFieldOrPropertyWithValue("description", "Description");
+            });
         }
     }
 


### PR DESCRIPTION
This broke the VirtualPrimaryKey plugin - and probably others too if they relied on the IntrospectedTable being complete when the initialized method was called.