### PR TITLE
Add Inferred Generated Key Plugin

### DIFF
--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/CodeGenerationAttributes.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/CodeGenerationAttributes.java
@@ -634,7 +634,7 @@ public abstract class CodeGenerationAttributes {
     }
 
     public TableConfiguration getTableConfiguration() {
-        return Objects.requireNonNull(tableConfiguration);
+        return tableConfiguration;
     }
 
     public KnownRuntime getKnownRuntime() {

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/IntrospectedColumn.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/IntrospectedColumn.java
@@ -23,6 +23,7 @@ import java.util.Properties;
 import org.jspecify.annotations.Nullable;
 import org.mybatis.generator.api.dom.java.FullyQualifiedJavaType;
 import org.mybatis.generator.config.Context;
+import org.mybatis.generator.config.GeneratedKey;
 import org.mybatis.generator.internal.util.StringUtility;
 
 /**
@@ -174,10 +175,6 @@ public class IntrospectedColumn {
         return identity;
     }
 
-    public void setIdentity(boolean identity) {
-        this.identity = identity;
-    }
-
     public boolean isBLOBColumn() {
         String typeName = getJdbcTypeName();
 
@@ -313,10 +310,6 @@ public class IntrospectedColumn {
         return isSequenceColumn;
     }
 
-    public void setSequenceColumn(boolean isSequenceColumn) {
-        this.isSequenceColumn = isSequenceColumn;
-    }
-
     public boolean isAutoIncrement() {
         return isAutoIncrement;
     }
@@ -354,5 +347,15 @@ public class IntrospectedColumn {
 
     public void setActualTypeName(String actualTypeName) {
         this.actualTypeName = actualTypeName;
+    }
+
+    public void acceptGeneratedKey(GeneratedKey generatedKey) {
+        if (generatedKey.isIdentity() || generatedKey.isJdbcStandard()) {
+            identity = true;
+            isSequenceColumn = false;
+        } else {
+            identity = false;
+            isSequenceColumn = true;
+        }
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/config/TableConfiguration.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/config/TableConfiguration.java
@@ -29,6 +29,7 @@ import java.util.Optional;
 import java.util.Properties;
 
 import org.jspecify.annotations.Nullable;
+import org.mybatis.generator.api.IntrospectedColumn;
 import org.mybatis.generator.api.KnownRuntime;
 import org.mybatis.generator.exception.InvalidConfigurationException;
 import org.mybatis.generator.internal.util.messages.Messages;
@@ -318,12 +319,14 @@ public class TableConfiguration extends PropertyHolder {
 
     }
 
-    public void setGeneratedKey(GeneratedKey generatedKey, Context context, KnownRuntime knownRuntime)
+    public void updateGeneratedKey(GeneratedKey generatedKey, IntrospectedColumn introspectedColumn, Context context,
+                                   KnownRuntime knownRuntime)
             throws InvalidConfigurationException {
         List<String> errors = validateGeneratedKey(generatedKey, context, knownRuntime);
 
         if (errors.isEmpty()) {
             this.generatedKey = generatedKey;
+            introspectedColumn.acceptGeneratedKey(generatedKey);
         } else {
             // TODO - externalize
             throw new InvalidConfigurationException("Updating the GeneratedKey would create an invalid configuration",

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/config/TableConfiguration.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/config/TableConfiguration.java
@@ -328,9 +328,7 @@ public class TableConfiguration extends PropertyHolder {
             this.generatedKey = generatedKey;
             introspectedColumn.acceptGeneratedKey(generatedKey);
         } else {
-            // TODO - externalize
-            throw new InvalidConfigurationException("Updating the GeneratedKey would create an invalid configuration",
-                    errors);
+            throw new InvalidConfigurationException(Messages.getString("ValidationError.35"), errors); //$NON-NLS-1$
         }
     }
 

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/config/TableConfiguration.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/config/TableConfiguration.java
@@ -30,6 +30,7 @@ import java.util.Properties;
 
 import org.jspecify.annotations.Nullable;
 import org.mybatis.generator.api.KnownRuntime;
+import org.mybatis.generator.exception.InvalidConfigurationException;
 import org.mybatis.generator.internal.util.messages.Messages;
 
 public class TableConfiguration extends PropertyHolder {
@@ -45,7 +46,7 @@ public class TableConfiguration extends PropertyHolder {
     // this is a Map for validation purposes. Initially, all items will be FALSE. When accessed, an item will
     // be made TRUE. This allows us to generate warning for columns configured to be ignored but not found.
     private final Map<IgnoredColumn, Boolean> ignoredColumns;
-    private final @Nullable GeneratedKey generatedKey;
+    private @Nullable GeneratedKey generatedKey;
     private final @Nullable String catalog;
     private final @Nullable String schema;
     private final String tableName;
@@ -271,20 +272,7 @@ public class TableConfiguration extends PropertyHolder {
         }
 
         if (generatedKey != null) {
-            // if the model type is immutable or record, then we cannot have generated keys
-            ModelType mt = getModelType().orElseGet(context::getDefaultModelType);
-            if (mt == ModelType.RECORD) {
-                errors.add(Messages.getString("ValidationError.30", fullyQualifiedName, context.getId(), //$NON-NLS-1$
-                        "record")); //$NON-NLS-1$
-            }
-
-            // we're going to allow generated keys for Kotlin even if the rest of the model is immutable
-            if (isImmutable(context) && knownRuntime != KnownRuntime.MYBATIS3_KOTLIN) {
-                errors.add(Messages.getString("ValidationError.30", fullyQualifiedName, context.getId(), //$NON-NLS-1$
-                        "immutable")); //$NON-NLS-1$
-            }
-
-            generatedKey.validate(errors, fullyQualifiedName, context.getId());
+            errors.addAll(validateGeneratedKey(generatedKey, context, knownRuntime));
         }
 
         if (domainObjectRenamingRule != null) {
@@ -305,6 +293,41 @@ public class TableConfiguration extends PropertyHolder {
 
         for (IgnoredColumnPattern ignoredColumnPattern : ignoredColumnPatterns) {
             ignoredColumnPattern.validate(errors, fullyQualifiedName);
+        }
+    }
+
+    private List<String> validateGeneratedKey(GeneratedKey generatedKey, Context context, KnownRuntime knownRuntime) {
+        List<String> errors = new ArrayList<>();
+
+        // if the model type is immutable or record, then we cannot have generated keys
+        ModelType mt = getModelType().orElseGet(context::getDefaultModelType);
+        if (mt == ModelType.RECORD) {
+            errors.add(Messages.getString("ValidationError.30", fullyQualifiedName, context.getId(), //$NON-NLS-1$
+                    "record")); //$NON-NLS-1$
+        }
+
+        // we're going to allow generated keys for Kotlin even if the rest of the model is immutable
+        if (isImmutable(context) && knownRuntime != KnownRuntime.MYBATIS3_KOTLIN) {
+            errors.add(Messages.getString("ValidationError.30", fullyQualifiedName, context.getId(), //$NON-NLS-1$
+                    "immutable")); //$NON-NLS-1$
+        }
+
+        generatedKey.validate(errors, fullyQualifiedName, context.getId());
+
+        return errors;
+
+    }
+
+    public void setGeneratedKey(GeneratedKey generatedKey, Context context, KnownRuntime knownRuntime)
+            throws InvalidConfigurationException {
+        List<String> errors = validateGeneratedKey(generatedKey, context, knownRuntime);
+
+        if (errors.isEmpty()) {
+            this.generatedKey = generatedKey;
+        } else {
+            // TODO - externalize
+            throw new InvalidConfigurationException("Updating the GeneratedKey would create an invalid configuration",
+                    errors);
         }
     }
 

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/internal/db/DatabaseIntrospector.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/internal/db/DatabaseIntrospector.java
@@ -274,15 +274,7 @@ public class DatabaseIntrospector {
         tc.getGeneratedKey().ifPresent(gk -> columns.values().stream()
                 .flatMap(List::stream)
                 .filter(introspectedColumn -> isMatchedColumn(introspectedColumn, gk))
-                .forEach(introspectedColumn -> {
-                    if (gk.isIdentity() || gk.isJdbcStandard()) {
-                        introspectedColumn.setIdentity(true);
-                        introspectedColumn.setSequenceColumn(false);
-                    } else {
-                        introspectedColumn.setIdentity(false);
-                        introspectedColumn.setSequenceColumn(true);
-                    }
-                }));
+                .forEach(introspectedColumn -> introspectedColumn.acceptGeneratedKey(gk)));
     }
 
     private boolean isMatchedColumn(IntrospectedColumn introspectedColumn, GeneratedKey gk) {

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/plugins/InferredGeneratedKeyPlugin.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/plugins/InferredGeneratedKeyPlugin.java
@@ -1,10 +1,27 @@
+/*
+ *    Copyright 2006-2026 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.mybatis.generator.plugins;
 
 import java.util.List;
 
+import org.mybatis.generator.api.IntrospectedColumn;
 import org.mybatis.generator.api.IntrospectedTable;
 import org.mybatis.generator.api.PluginAdapter;
 import org.mybatis.generator.config.GeneratedKey;
+import org.mybatis.generator.exception.InvalidConfigurationException;
 
 public class InferredGeneratedKeyPlugin extends PluginAdapter {
 
@@ -15,6 +32,12 @@ public class InferredGeneratedKeyPlugin extends PluginAdapter {
 
     @Override
     public void initialized(IntrospectedTable introspectedTable) {
+        boolean skipped = Boolean.parseBoolean(introspectedTable
+                .getTableConfigurationProperty("skipInferredGeneratedKeyPlugin")); //$NON-NLS-1$
+        if (skipped) {
+            return;
+        }
+
         // if there is already a generated key, do not override it
         if (introspectedTable.getGeneratedKey().isPresent()) {
             return;
@@ -27,12 +50,23 @@ public class InferredGeneratedKeyPlugin extends PluginAdapter {
 
         var column = introspectedTable.getPrimaryKeyColumns().get(0);
 
-        if (!column.isGeneratedColumn()) {
+        if (!columnsHasGeneratedValue(column)) {
             return;
         }
 
-        GeneratedKey generatedKey = new GeneratedKey(column.getActualColumnName(), "JDBC", true);
+        GeneratedKey generatedKey = new GeneratedKey(column.getActualColumnName(), "JDBC", true); //$NON-NLS-1$
 
-//        introspectedTable.setGeneratedKey(generatedKey);
+        try {
+            introspectedTable.getTableConfiguration().setGeneratedKey(generatedKey, getContext(), getKnownRuntime());
+            column.setIdentity(true);
+            column.setSequenceColumn(false);
+        } catch (InvalidConfigurationException e) {
+            throw new RuntimeException("InvalidConfigurationException changing generated key for table "
+                    + introspectedTable.getFullyQualifiedTable(), e);
+        }
+    }
+
+    private boolean columnsHasGeneratedValue(IntrospectedColumn column) {
+        return column.isGeneratedColumn() || column.isAutoIncrement();
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/plugins/InferredGeneratedKeyPlugin.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/plugins/InferredGeneratedKeyPlugin.java
@@ -1,0 +1,38 @@
+package org.mybatis.generator.plugins;
+
+import java.util.List;
+
+import org.mybatis.generator.api.IntrospectedTable;
+import org.mybatis.generator.api.PluginAdapter;
+import org.mybatis.generator.config.GeneratedKey;
+
+public class InferredGeneratedKeyPlugin extends PluginAdapter {
+
+    @Override
+    public boolean validate(List<String> warnings) {
+        return true;
+    }
+
+    @Override
+    public void initialized(IntrospectedTable introspectedTable) {
+        // if there is already a generated key, do not override it
+        if (introspectedTable.getGeneratedKey().isPresent()) {
+            return;
+        }
+
+        // we only do this for single primary keys
+        if (introspectedTable.getPrimaryKeyColumns().size() != 1) {
+            return;
+        }
+
+        var column = introspectedTable.getPrimaryKeyColumns().get(0);
+
+        if (!column.isGeneratedColumn()) {
+            return;
+        }
+
+        GeneratedKey generatedKey = new GeneratedKey(column.getActualColumnName(), "JDBC", true);
+
+//        introspectedTable.setGeneratedKey(generatedKey);
+    }
+}

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/plugins/InferredGeneratedKeyPlugin.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/plugins/InferredGeneratedKeyPlugin.java
@@ -15,8 +15,11 @@
  */
 package org.mybatis.generator.plugins;
 
+import java.text.MessageFormat;
 import java.util.List;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.mybatis.generator.api.IntrospectedColumn;
 import org.mybatis.generator.api.IntrospectedTable;
 import org.mybatis.generator.api.PluginAdapter;
@@ -24,6 +27,7 @@ import org.mybatis.generator.config.GeneratedKey;
 import org.mybatis.generator.exception.InvalidConfigurationException;
 
 public class InferredGeneratedKeyPlugin extends PluginAdapter {
+    private static final Log LOGGER = LogFactory.getLog(InferredGeneratedKeyPlugin.class);
 
     @Override
     public boolean validate(List<String> warnings) {
@@ -32,37 +36,42 @@ public class InferredGeneratedKeyPlugin extends PluginAdapter {
 
     @Override
     public void initialized(IntrospectedTable introspectedTable) {
-        boolean skipped = Boolean.parseBoolean(introspectedTable
-                .getTableConfigurationProperty("skipInferredGeneratedKeyPlugin")); //$NON-NLS-1$
-        if (skipped) {
-            return;
-        }
-
         // if there is already a generated key, do not override it
         if (introspectedTable.getGeneratedKey().isPresent()) {
+            LOGGER.info(MessageFormat.format(
+                    "Skipping InferredGeneratedKeyPlugin because table {0} already has a generated key configured",
+                            introspectedTable.getFullyQualifiedTable()));
             return;
         }
 
         // we only do this for single primary keys
         if (introspectedTable.getPrimaryKeyColumns().size() != 1) {
+            LOGGER.info(MessageFormat.format(
+                    "Skipping InferredGeneratedKeyPlugin because table {0} does not have a single column primary key",
+                    introspectedTable.getFullyQualifiedTable()));
             return;
         }
 
         var column = introspectedTable.getPrimaryKeyColumns().get(0);
 
         if (!columnsHasGeneratedValue(column)) {
+            LOGGER.info(MessageFormat.format(
+                    "Skipping InferredGeneratedKeyPlugin "
+                            + " because table {0} does not have a generated primary key column",
+                    introspectedTable.getFullyQualifiedTable()));
             return;
         }
 
         GeneratedKey generatedKey = new GeneratedKey(column.getActualColumnName(), "JDBC", true); //$NON-NLS-1$
 
         try {
-            introspectedTable.getTableConfiguration().setGeneratedKey(generatedKey, getContext(), getKnownRuntime());
-            column.setIdentity(true);
-            column.setSequenceColumn(false);
+            introspectedTable.getTableConfiguration().updateGeneratedKey(generatedKey, column, getContext(),
+                    getKnownRuntime());
         } catch (InvalidConfigurationException e) {
-            throw new RuntimeException("InvalidConfigurationException changing generated key for table "
-                    + introspectedTable.getFullyQualifiedTable(), e);
+            LOGGER.info(MessageFormat.format(
+                    "Skipping InferredGeneratedKeyPlugin on table {0} because of InvalidConfigurationException",
+                    introspectedTable.getFullyQualifiedTable()));
+            e.getExtraMessages().forEach(LOGGER::info);
         }
     }
 

--- a/core/mybatis-generator-core/src/main/resources/org/mybatis/generator/internal/util/messages/messages.properties
+++ b/core/mybatis-generator-core/src/main/resources/org/mybatis/generator/internal/util/messages/messages.properties
@@ -50,6 +50,7 @@ ValidationError.31=Invalid clientGenerator type "{0}" in context {1}
 ValidationError.32=Invalid Configuration, see detailed messages for reasons
 ValidationError.33=Invalid {0} indent type in {1} context
 ValidationError.34=Invalid {0} indent amount in {1} context
+ValidationError.35=Updating the GeneratedKey would create an invalid configuration. See detailed messages for reasons.
 
 RuntimeError.0=configfile is a required parameter
 RuntimeError.1=configfile {0} does not exist

--- a/core/mybatis-generator-core/src/site/xhtml/reference/plugins.xhtml
+++ b/core/mybatis-generator-core/src/site/xhtml/reference/plugins.xhtml
@@ -125,6 +125,19 @@ The plugin will create the additional Methods:
     a wildcard to select many tables and views, but don't want to generate code for the views.
 </p>
 
+<h2>org.mybatis.generator.plugins.InferredGeneratedKeyPlugin</h2>
+<p>This plugin will calculate a &lt;generatedKey&gt; configuration for any table that meets the following
+  requirements:
+</p>
+<ol>
+  <li>The table must have one, and only one, primary key column</li>
+  <li>The primary key column must be a generated value or autoincrement column</li>
+  <li>The table configuration must not have a manually defined &lt;generatedKey&gt; configuration</li>
+</ol>
+<p>This plugin is helpful if you have specified a wild card value for a table name. The plugin can add generated
+  key configuration to multiple tables that meet the above requirements.
+</p>
+
 <h2>org.mybatis.generator.plugins.JSpecifyPlugin</h2>
 <p>This plugin adds a JSpecify <code>@NullMarked</code> annotation to generated mappers and DSQL support classes.
   In addition, the plugin will add annotations to generated model classes and records as described below.

--- a/core/mybatis-generator-core/src/site/xhtml/whatsNew.xhtml
+++ b/core/mybatis-generator-core/src/site/xhtml/whatsNew.xhtml
@@ -31,9 +31,13 @@
   <li>Enhancement - Indentation specifications for generated code can now be configured. See the
     <a href="configreference/indentation.html">Indentation Configuration Page</a> for further details.
   </li>
+  <li>Enhancement - add InferredGeneratedKeyPlugin that will automatically calculate a generated key configuration
+    for a table if it has one primary key column, and the column value is generated.
+  </li>
   <li>Bug Fix – The plugin "initialized" method was being called too early – before the IntrospectedTable was completely
     initialized. This would break plugins that relied on the IntrospectedTable being fully initialized.
   </li>
+
 </ul>
 
 <h2>Version 2.0.0</h2>

--- a/core/mybatis-generator-core/src/test/resources/scripts/generatorConfig-kotlin.xml
+++ b/core/mybatis-generator-core/src/test/resources/scripts/generatorConfig-kotlin.xml
@@ -99,9 +99,7 @@
     <table tableName="PKFieldsBlobs" />
     <table tableName="FieldsBlobs" />
     <table tableName="awful table" alias="A">
-      <!--
-      <generatedKey column="CuStOmEr iD" sqlStatement="JDBC" />
-      -->
+      <!-- generatedKey is inferred by plugin -->
       <columnOverride column="first name" property="firstFirstName" />
       <columnOverride column="first_name" property="secondFirstName" />
       <columnOverride column="firstName" property="thirdFirstName" />

--- a/core/mybatis-generator-core/src/test/resources/scripts/generatorConfig-kotlin.xml
+++ b/core/mybatis-generator-core/src/test/resources/scripts/generatorConfig-kotlin.xml
@@ -77,6 +77,8 @@
   </context>
 
   <context id="idiomatic-kotlin" targetRuntime="MyBatis3Kotlin">
+    <plugin type="org.mybatis.generator.plugins.InferredGeneratedKeyPlugin" />
+
     <jdbcConnection driverClass="org.hsqldb.jdbcDriver" connectionURL="jdbc:hsqldb:mem:aname" userId="sa" />
 
     <modelGenerator targetPackage="mbg.test.mb3.generated.dsql.kotlin.idiomatic.model" targetProject="MAVEN" />
@@ -97,7 +99,9 @@
     <table tableName="PKFieldsBlobs" />
     <table tableName="FieldsBlobs" />
     <table tableName="awful table" alias="A">
+      <!--
       <generatedKey column="CuStOmEr iD" sqlStatement="JDBC" />
+      -->
       <columnOverride column="first name" property="firstFirstName" />
       <columnOverride column="first_name" property="secondFirstName" />
       <columnOverride column="firstName" property="thirdFirstName" />

--- a/core/mybatis-generator-core/src/test/resources/scripts/generatorConfig.xml
+++ b/core/mybatis-generator-core/src/test/resources/scripts/generatorConfig.xml
@@ -30,6 +30,7 @@
     <plugin type="org.mybatis.generator.plugins.RowBoundsPlugin" />
     <plugin type="org.mybatis.generator.plugins.ToStringPlugin" />
     <plugin type="org.mybatis.generator.plugins.MapperAnnotationPlugin" />
+    <plugin type="org.mybatis.generator.plugins.InferredGeneratedKeyPlugin" /> <!-- should have no impact -->
 
     <connectionFactory>
       <property name="driverClass" value="org.hsqldb.jdbcDriver"/>

--- a/core/mybatis-generator-systests-kotlin/src/main/resources/generatorConfig.xml
+++ b/core/mybatis-generator-systests-kotlin/src/main/resources/generatorConfig.xml
@@ -77,6 +77,8 @@
   </context>
 
   <context id="idiomatic-kotlin" targetRuntime="MyBatis3Kotlin">
+    <plugin type="org.mybatis.generator.plugins.InferredGeneratedKeyPlugin" />
+
     <jdbcConnection driverClass="org.hsqldb.jdbcDriver" connectionURL="jdbc:hsqldb:mem:aname" userId="sa" />
 
     <modelGenerator targetPackage="mbg.test.mb3.generated.dsql.kotlin.idiomatic.model" targetProject="MAVEN" />
@@ -97,7 +99,7 @@
     <table tableName="PKFieldsBlobs" />
     <table tableName="FieldsBlobs" />
     <table tableName="awful table" alias="A">
-      <generatedKey column="CuStOmEr iD" sqlStatement="JDBC" />
+      <!-- generatedKey is inferred by plugin -->
       <columnOverride column="first name" property="firstFirstName" />
       <columnOverride column="first_name" property="secondFirstName" />
       <columnOverride column="firstName" property="thirdFirstName" />

--- a/core/mybatis-generator-systests-mybatis3/src/main/resources/generatorConfig.xml
+++ b/core/mybatis-generator-systests-mybatis3/src/main/resources/generatorConfig.xml
@@ -30,6 +30,7 @@
     <plugin type="org.mybatis.generator.plugins.RowBoundsPlugin" />
     <plugin type="org.mybatis.generator.plugins.ToStringPlugin" />
     <plugin type="org.mybatis.generator.plugins.MapperAnnotationPlugin" />
+    <plugin type="org.mybatis.generator.plugins.InferredGeneratedKeyPlugin" /> <!-- should have no impact -->
 
     <connectionFactory>
       <property name="driverClass" value="org.hsqldb.jdbcDriver"/>


### PR DESCRIPTION
This PR adds the ability to specify a generated key in a plugin. It also adds an example plugin `InferredGeneratedKeyPlugin`. The plugin will add generated key configuration for tables that meet the following requirements:

- The table must have one, and only one, primary key column
- The primary key column must be a generated value or autoincrement column
- The table configuration must not have a manually defined `<generatedKey>` configuration

Resolves #1509 