### PR TITLE
Java Merger Polishing

### DIFF
--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/merge/java/AbstractJavaMerger.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/merge/java/AbstractJavaMerger.java
@@ -1,0 +1,68 @@
+/*
+ *    Copyright 2006-2026 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.generator.merge.java;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.printer.Printer;
+import org.mybatis.generator.exception.MergeException;
+
+public abstract class AbstractJavaMerger implements JavaFileMerger {
+    protected final Printer printer;
+    private final boolean isLexicalPreserving;
+
+    protected  AbstractJavaMerger(Printer printer, boolean isLexicalPreserving) {
+        this.printer = printer;
+        this.isLexicalPreserving = isLexicalPreserving;
+    }
+
+    /**
+     * Merge a newly generated Java file with existing Java file content.
+     *
+     * @param newFileContent the content of the newly generated Java file
+     * @param existingFileContent the content of the existing Java file
+     * @return the merged source, properly formatted
+     * @throws MergeException if the file cannot be merged for some reason
+     */
+    @Override
+    public String getMergedSource(String newFileContent, String existingFileContent) throws MergeException {
+        ParserConfiguration parserConfiguration = new ParserConfiguration();
+        parserConfiguration.setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_25);
+        if (isLexicalPreserving) {
+            parserConfiguration.setLexicalPreservationEnabled(true);
+        }
+        JavaParser javaParser = new JavaParser(parserConfiguration);
+
+        ParseResults existingFileParseResults = JavaMergeUtilities.parseAndFindMainTypeDeclaration(javaParser,
+                existingFileContent, MergeFileType.EXISTING_FILE);
+
+        // Gather custom members from the existing file. If none, just return the new file as is
+        CustomMemberGatherer customMemberGatherer =
+                new CustomMemberGatherer(existingFileParseResults.typeDeclaration());
+        if (!customMemberGatherer.hasAnyMembersToMerge()) {
+            return newFileContent;
+        }
+
+        // Custom members exist, need to merge...
+        ParseResults newFileParseResults = JavaMergeUtilities.parseAndFindMainTypeDeclaration(javaParser,
+                newFileContent, MergeFileType.NEW_FILE);
+
+        return performMerge(customMemberGatherer, existingFileParseResults, newFileParseResults);
+    }
+
+    protected abstract String performMerge(CustomMemberGatherer customMemberGatherer,
+                                           ParseResults existingFileParseResults, ParseResults newFileParseResults);
+}

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/merge/java/JavaMergeUtilities.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/merge/java/JavaMergeUtilities.java
@@ -99,30 +99,13 @@ public class JavaMergeUtilities {
         return false;
     }
 
-    public static void copyMissingSuperInterfaces(BodyDeclaration<?> targetType, BodyDeclaration<?> sourceType) {
-        List<String> sourceSuperInterfaces = findSuperInterfaces(sourceType).stream()
+    public static void copyMissingSuperInterfaces(BodyDeclaration<?> sourceType, BodyDeclaration<?> targetType) {
+        List<String> targetSuperInterfaces = findSuperInterfaces(targetType).stream()
                 .map(NodeWithSimpleName::getNameAsString).toList();
 
-        findSuperInterfaces(targetType).stream()
-                .filter(si -> !sourceSuperInterfaces.contains(si.getNameAsString()))
-                .toList()
+        findSuperInterfaces(sourceType).stream()
+                .filter(t -> !targetSuperInterfaces.contains(t.getNameAsString()))
                 .forEach(t -> addSuperInterface(targetType, t));
-    }
-
-    public static List<ClassOrInterfaceType> findCustomSuperInterfaces(BodyDeclaration<?> existingType,
-                                                                       BodyDeclaration<?> newType) {
-        List<ClassOrInterfaceType> customSuperInterfaces = new ArrayList<>();
-
-        List<String> newFileSuperInterfaces = findSuperInterfaces(newType).stream()
-                .map(NodeWithSimpleName::getNameAsString).toList();
-
-        for (ClassOrInterfaceType id : findSuperInterfaces(existingType)) {
-            if (!newFileSuperInterfaces.contains(id.getNameAsString())) {
-                customSuperInterfaces.add(id);
-            }
-        }
-
-        return customSuperInterfaces;
     }
 
     private static List<ClassOrInterfaceType> findSuperInterfaces(BodyDeclaration<?> bodyDeclaration) {
@@ -137,7 +120,7 @@ public class JavaMergeUtilities {
         return Collections.emptyList();
     }
 
-    public static void addSuperInterface(BodyDeclaration<?> bodyDeclaration, ClassOrInterfaceType superInterface) {
+    private static void addSuperInterface(BodyDeclaration<?> bodyDeclaration, ClassOrInterfaceType superInterface) {
         if (bodyDeclaration.isClassOrInterfaceDeclaration()) {
             bodyDeclaration.asClassOrInterfaceDeclaration().addImplementedType(superInterface);
         } else if (bodyDeclaration.isEnumDeclaration()) {

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/merge/java/JavaMergeUtilities.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/merge/java/JavaMergeUtilities.java
@@ -99,6 +99,16 @@ public class JavaMergeUtilities {
         return false;
     }
 
+    public static void copyMissingSuperInterfaces(BodyDeclaration<?> targetType, BodyDeclaration<?> sourceType) {
+        List<String> sourceSuperInterfaces = findSuperInterfaces(sourceType).stream()
+                .map(NodeWithSimpleName::getNameAsString).toList();
+
+        findSuperInterfaces(targetType).stream()
+                .filter(si -> !sourceSuperInterfaces.contains(si.getNameAsString()))
+                .toList()
+                .forEach(t -> addSuperInterface(targetType, t));
+    }
+
     public static List<ClassOrInterfaceType> findCustomSuperInterfaces(BodyDeclaration<?> existingType,
                                                                        BodyDeclaration<?> newType) {
         List<ClassOrInterfaceType> customSuperInterfaces = new ArrayList<>();

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/merge/java/JavaMergeUtilities.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/merge/java/JavaMergeUtilities.java
@@ -17,7 +17,6 @@ package org.mybatis.generator.merge.java;
 
 import static org.mybatis.generator.internal.util.messages.Messages.getString;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -49,28 +48,22 @@ public class JavaMergeUtilities {
     }
 
     /**
-     * Compare two compilation units and find imports that are in the existing file but not in the new file.
-     * We assume this means they are required for some custom method, so we will add them to the new
-     * file if there are other items to merge. This may create unused imports in the new file if the
+     * Compare two compilation units and find imports that are in the source file but not in the target file.
+     * We assume this means they are required for some custom method, so we will add them to the target
+     * file if there are other items to merge. This may create unused imports in the target file if the
      * initial assumption is incorrect, but better safe than sorry.
      *
-     * @param existingCompilationUnit compilation unit representing the existing file
-     * @param newCompilationUnit compilation unit representing the new file
+     * @param sourceCompilationUnit compilation unit representing the source file
+     * @param targetCompilationUnit compilation unit representing the target file
      */
-    public static List<ImportDeclaration> findCustomImports(CompilationUnit existingCompilationUnit,
-                                                            CompilationUnit newCompilationUnit) {
-        List<ImportDeclaration> customImports = new ArrayList<>();
-
-        List<String> newFileImports = newCompilationUnit.getImports().stream()
+    public static void copyMissingImports(CompilationUnit sourceCompilationUnit,
+                                          CompilationUnit targetCompilationUnit) {
+        List<String> newFileImports = targetCompilationUnit.getImports().stream()
                 .map(JavaMergeUtilities::stringify).toList();
 
-        for (ImportDeclaration id : existingCompilationUnit.getImports()) {
-            if (!newFileImports.contains(stringify(id))) {
-                customImports.add(id);
-            }
-        }
-
-        return customImports;
+        sourceCompilationUnit.getImports().stream()
+                .filter(im -> !newFileImports.contains(stringify(im)))
+                .forEach(targetCompilationUnit::addImport);
     }
 
     /**

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/merge/java/MergeIntoExistingJavaFileMerger.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/merge/java/MergeIntoExistingJavaFileMerger.java
@@ -77,7 +77,6 @@ public class MergeIntoExistingJavaFileMerger extends AbstractJavaMerger {
     public String performMerge(CustomMemberGatherer customMemberGatherer, ParseResults existingFileParseResults,
                                ParseResults newFileParseResults) {
         TypeDeclaration<?> existingType = existingFileParseResults.typeDeclaration();
-        TypeDeclaration<?> newType = newFileParseResults.typeDeclaration();
 
         // remove generated elements from the existing file
         existingType.getMembers().stream()
@@ -95,6 +94,8 @@ public class MergeIntoExistingJavaFileMerger extends AbstractJavaMerger {
 
         // delete any members in the new file that match the old file members (this gets rid of new
         // do not delete members)
+        TypeDeclaration<?> newType = newFileParseResults.typeDeclaration();
+
         for (BodyDeclaration<?> member : existingType.getMembers()) {
             JavaMergeUtilities.deleteDuplicateMemberIfExists(newType, member);
         }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/merge/java/MergeIntoExistingJavaFileMerger.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/merge/java/MergeIntoExistingJavaFileMerger.java
@@ -116,8 +116,7 @@ public class MergeIntoExistingJavaFileMerger extends AbstractJavaMerger {
                 .forEach(existingFileParseResults.compilationUnit()::addImport);
 
         // Look for super interfaces in the new file and merge into the existing file if they aren't present
-        JavaMergeUtilities.findCustomSuperInterfaces(newType, existingType)
-                .forEach(t -> JavaMergeUtilities.addSuperInterface(existingType, t));
+        JavaMergeUtilities.copyMissingSuperInterfaces(newType, existingType);
 
         // merge records - this is not really a merge so much as a replacement. We would need to add the @Generated
         // annotation to record fields to perform a merge, which seems excessive.

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/merge/java/MergeIntoExistingJavaFileMerger.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/merge/java/MergeIntoExistingJavaFileMerger.java
@@ -15,15 +15,9 @@
  */
 package org.mybatis.generator.merge.java;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import com.github.javaparser.JavaParser;
-import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.ast.body.BodyDeclaration;
-import com.github.javaparser.ast.body.EnumConstantDeclaration;
+import com.github.javaparser.ast.body.TypeDeclaration;
 import com.github.javaparser.printer.Printer;
-import org.mybatis.generator.exception.MergeException;
 
 /**
  * This class handles the task of merging changes into an existing Java file using JavaParser.
@@ -74,96 +68,46 @@ import org.mybatis.generator.exception.MergeException;
  *
  * @author Jeff Butler
  */
-public class MergeIntoExistingJavaFileMerger implements JavaFileMerger {
-    private final Printer printer;
-    private final boolean isLexicalPreserving;
-
+public class MergeIntoExistingJavaFileMerger extends AbstractJavaMerger {
     public MergeIntoExistingJavaFileMerger(Printer printer, boolean isLexicalPreserving) {
-        this.printer = printer;
-        this.isLexicalPreserving = isLexicalPreserving;
+        super(printer, isLexicalPreserving);
     }
 
-    /**
-     * Merge a newly generated Java file with existing Java file content.
-     *
-     * @param newFileContent the content of the newly generated Java file
-     * @param existingFileContent the content of the existing Java file
-     * @return the merged source, properly formatted
-     * @throws MergeException if the file cannot be merged for some reason
-     */
     @Override
-    public String getMergedSource(String newFileContent, String existingFileContent) throws MergeException {
-        ParserConfiguration parserConfiguration = new ParserConfiguration();
-        parserConfiguration.setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_25);
-        if (isLexicalPreserving) {
-            parserConfiguration.setLexicalPreservationEnabled(true);
-        }
-
-        JavaParser javaParser = new JavaParser(parserConfiguration);
-
-        ParseResults existingFileParseResults = JavaMergeUtilities.parseAndFindMainTypeDeclaration(javaParser,
-                existingFileContent, MergeFileType.EXISTING_FILE);
-
-        // Gather custom members from the existing file. If none, just return the new file as is
-        CustomMemberGatherer customMemberGatherer =
-                new CustomMemberGatherer(existingFileParseResults.typeDeclaration());
-        if (!customMemberGatherer.hasAnyMembersToMerge()) {
-            return newFileContent;
-        }
+    public String performMerge(CustomMemberGatherer customMemberGatherer, ParseResults existingFileParseResults,
+                               ParseResults newFileParseResults) {
+        TypeDeclaration<?> existingType = existingFileParseResults.typeDeclaration();
+        TypeDeclaration<?> newType = newFileParseResults.typeDeclaration();
 
         // remove generated elements from the existing file
-        List<BodyDeclaration<?>> membersToDelete = new ArrayList<>();
-        existingFileParseResults.typeDeclaration().getMembers().forEach(member -> {
-            GeneratedType generatedType = JavaMergeUtilities.checkForGeneratedAnnotation(member);
-            if (generatedType == GeneratedType.GENERATED_REMOVE) {
-                membersToDelete.add(member);
-            }
-            generatedType = JavaMergeUtilities.checkForGeneratedJavadocTag(member);
-            if (generatedType == GeneratedType.GENERATED_REMOVE) {
-                membersToDelete.add(member);
-            }
-        });
-        for (BodyDeclaration<?> member : membersToDelete) {
-            existingFileParseResults.typeDeclaration().remove(member);
-        }
+        existingType.getMembers().stream()
+                .filter(this::shouldDelete)
+                .toList()
+                .forEach(existingType::remove);
 
         // Remove generated enum constants
-        if (existingFileParseResults.typeDeclaration().isEnumDeclaration()) {
-            List<EnumConstantDeclaration> enumConstantsToDelete = new ArrayList<>();
-            existingFileParseResults.typeDeclaration().asEnumDeclaration().getEntries().forEach(enumDec -> {
-                GeneratedType generatedType = JavaMergeUtilities.checkForGeneratedAnnotation(enumDec);
-                if (generatedType == GeneratedType.GENERATED_REMOVE) {
-                    enumConstantsToDelete.add(enumDec);
-                }
-                generatedType = JavaMergeUtilities.checkForGeneratedJavadocTag(enumDec);
-                if (generatedType == GeneratedType.GENERATED_REMOVE) {
-                    enumConstantsToDelete.add(enumDec);
-                }
-            });
-            for (EnumConstantDeclaration member : enumConstantsToDelete) {
-                existingFileParseResults.typeDeclaration().asEnumDeclaration().remove(member);
-            }
+        if (existingType.isEnumDeclaration()) {
+            existingType.asEnumDeclaration().getEntries().stream()
+                    .filter(this::shouldDelete)
+                    .toList()
+                    .forEach(existingType::remove);
         }
-
-        // 2. Parse the new file, gather generated elements and add to the existing file
-        ParseResults newFileParseResults = JavaMergeUtilities.parseAndFindMainTypeDeclaration(javaParser,
-                newFileContent, MergeFileType.NEW_FILE);
 
         // delete any members in the new file that match the old file members (this gets rid of new
         // do not delete members)
-        for (BodyDeclaration<?> member : existingFileParseResults.typeDeclaration().getMembers()) {
-            JavaMergeUtilities.deleteDuplicateMemberIfExists(newFileParseResults.typeDeclaration(), member);
+        for (BodyDeclaration<?> member : existingType.getMembers()) {
+            JavaMergeUtilities.deleteDuplicateMemberIfExists(newType, member);
         }
 
         // add members from the new file to the existing file
-        for (BodyDeclaration<?> member : newFileParseResults.typeDeclaration().getMembers()) {
-            existingFileParseResults.typeDeclaration().addMember(member);
+        for (BodyDeclaration<?> member : newType.getMembers()) {
+            existingType.addMember(member);
         }
 
         // add any enum constants from the new file to the existing file
-        if (newFileParseResults.typeDeclaration().isEnumDeclaration()) {
-            existingFileParseResults.typeDeclaration().asEnumDeclaration().getEntries().addAll(
-                    newFileParseResults.typeDeclaration().asEnumDeclaration().getEntries());
+        if (newType.isEnumDeclaration() && existingType.isEnumDeclaration()) {
+            existingType.asEnumDeclaration().getEntries().addAll(
+                    newType.asEnumDeclaration().getEntries());
         }
 
         // 3. Add imports to existing file from new file that are not in existing file
@@ -172,21 +116,28 @@ public class MergeIntoExistingJavaFileMerger implements JavaFileMerger {
                 .forEach(existingFileParseResults.compilationUnit()::addImport);
 
         // Look for super interfaces in the new file and merge into the existing file if they aren't present
-        JavaMergeUtilities.findCustomSuperInterfaces(newFileParseResults.typeDeclaration(),
-                        existingFileParseResults.typeDeclaration())
-                .forEach(t -> JavaMergeUtilities.addSuperInterface(existingFileParseResults.typeDeclaration(), t));
+        JavaMergeUtilities.findCustomSuperInterfaces(newType, existingType)
+                .forEach(t -> JavaMergeUtilities.addSuperInterface(existingType, t));
 
-        // merge records
-        // TODO(?) this is not really a merge so much as a replace - should we do a merge?
-        if (existingFileParseResults.typeDeclaration().isRecordDeclaration()
-                && newFileParseResults.typeDeclaration().isRecordDeclaration()) {
+        // merge records - this is not really a merge so much as a replacement. We would need to add the @Generated
+        // annotation to record fields to perform a merge, which seems excessive.
+        if (existingType.isRecordDeclaration() && newType.isRecordDeclaration()) {
             // remove all record fields from the existing file and add from the new file
-            existingFileParseResults.typeDeclaration().asRecordDeclaration().getParameters().clear();
-            existingFileParseResults.typeDeclaration().asRecordDeclaration().getParameters().addAll(
-                    newFileParseResults.typeDeclaration().asRecordDeclaration().getParameters());
+            existingType.asRecordDeclaration().getParameters().clear();
+            existingType.asRecordDeclaration().getParameters()
+                    .addAll(newType.asRecordDeclaration().getParameters());
         }
 
         // Return the new (merged) file
         return printer.print(existingFileParseResults.compilationUnit());
+    }
+
+    private boolean shouldDelete(BodyDeclaration<?> bodyDeclaration) {
+        GeneratedType generatedType = JavaMergeUtilities.checkForGeneratedAnnotation(bodyDeclaration);
+        if (generatedType == GeneratedType.GENERATED_REMOVE) {
+            return true;
+        }
+        generatedType = JavaMergeUtilities.checkForGeneratedJavadocTag(bodyDeclaration);
+        return generatedType == GeneratedType.GENERATED_REMOVE;
     }
 }

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/merge/java/MergeIntoExistingJavaFileMerger.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/merge/java/MergeIntoExistingJavaFileMerger.java
@@ -82,14 +82,14 @@ public class MergeIntoExistingJavaFileMerger extends AbstractJavaMerger {
         // remove generated elements from the existing file
         existingType.getMembers().stream()
                 .filter(this::shouldDelete)
-                .toList()
+                .toList() // this avoids a concurrent modification problem
                 .forEach(existingType::remove);
 
         // Remove generated enum constants
         if (existingType.isEnumDeclaration()) {
             existingType.asEnumDeclaration().getEntries().stream()
                     .filter(this::shouldDelete)
-                    .toList()
+                    .toList() // this avoids a concurrent modification problem
                     .forEach(existingType::remove);
         }
 
@@ -112,8 +112,7 @@ public class MergeIntoExistingJavaFileMerger extends AbstractJavaMerger {
 
         // 3. Add imports to existing file from new file that are not in existing file
         JavaMergeUtilities
-                .findCustomImports(newFileParseResults.compilationUnit(), existingFileParseResults.compilationUnit())
-                .forEach(existingFileParseResults.compilationUnit()::addImport);
+                .copyMissingImports(newFileParseResults.compilationUnit(), existingFileParseResults.compilationUnit());
 
         // Look for super interfaces in the new file and merge into the existing file if they aren't present
         JavaMergeUtilities.copyMissingSuperInterfaces(newType, existingType);

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/merge/java/MergeIntoNewJavaFileMerger.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/merge/java/MergeIntoNewJavaFileMerger.java
@@ -77,7 +77,6 @@ public class MergeIntoNewJavaFileMerger extends AbstractJavaMerger {
     @Override
     public String performMerge(CustomMemberGatherer customMemberGatherer, ParseResults existingFileParseResults,
                                ParseResults newFileParseResults) {
-        TypeDeclaration<?> existingType = existingFileParseResults.typeDeclaration();
         TypeDeclaration<?> newType = newFileParseResults.typeDeclaration();
 
         // Delete elements in the new file that match doNotDeleteMembers from the existing file
@@ -97,7 +96,7 @@ public class MergeIntoNewJavaFileMerger extends AbstractJavaMerger {
         }
 
         // Look for custom super interfaces in the existing file and merge into the new file
-        JavaMergeUtilities.copyMissingSuperInterfaces(existingType, newType);
+        JavaMergeUtilities.copyMissingSuperInterfaces(existingFileParseResults.typeDeclaration(), newType);
 
         // Return the new (merged) file
         return printer.print(newFileParseResults.compilationUnit());

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/merge/java/MergeIntoNewJavaFileMerger.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/merge/java/MergeIntoNewJavaFileMerger.java
@@ -98,8 +98,7 @@ public class MergeIntoNewJavaFileMerger extends AbstractJavaMerger {
         }
 
         // Look for custom super interfaces in the existing file and merge into the new file
-        JavaMergeUtilities.findCustomSuperInterfaces(existingType, newType)
-                .forEach(t -> JavaMergeUtilities.addSuperInterface(newType, t));
+        JavaMergeUtilities.copyMissingSuperInterfaces(existingType, newType);
 
         // Return the new (merged) file
         return printer.print(newFileParseResults.compilationUnit());

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/merge/java/MergeIntoNewJavaFileMerger.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/merge/java/MergeIntoNewJavaFileMerger.java
@@ -86,8 +86,7 @@ public class MergeIntoNewJavaFileMerger extends AbstractJavaMerger {
 
         // Look for custom imports in the existing file and merge into the new file
         JavaMergeUtilities
-                .findCustomImports(existingFileParseResults.compilationUnit(), newFileParseResults.compilationUnit())
-                .forEach(newFileParseResults.compilationUnit()::addImport);
+                .copyMissingImports(existingFileParseResults.compilationUnit(), newFileParseResults.compilationUnit());
 
         // Add custom body members from the existing file to the new file
         customMemberGatherer.allCustomBodyMembers().forEach(newType::addMember);

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/merge/java/MergeIntoNewJavaFileMerger.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/merge/java/MergeIntoNewJavaFileMerger.java
@@ -15,10 +15,8 @@
  */
 package org.mybatis.generator.merge.java;
 
-import com.github.javaparser.JavaParser;
-import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.ast.body.TypeDeclaration;
 import com.github.javaparser.printer.Printer;
-import org.mybatis.generator.exception.MergeException;
 
 /**
  * This class handles the task of merging changes into a new Java file using JavaParser.
@@ -70,50 +68,21 @@ import org.mybatis.generator.exception.MergeException;
  * @author Freeman (original)
  * @author Jeff Butler (refactoring and enhancements)
  */
-public class MergeIntoNewJavaFileMerger implements JavaFileMerger {
-    private final Printer printer;
-    private final boolean isLexicalPreserving;
+public class MergeIntoNewJavaFileMerger extends AbstractJavaMerger {
 
     public MergeIntoNewJavaFileMerger(Printer printer, boolean isLexicalPreserving) {
-        this.printer = printer;
-        this.isLexicalPreserving = isLexicalPreserving;
+        super(printer, isLexicalPreserving);
     }
 
-    /**
-     * Merge a newly generated Java file with existing Java file content.
-     *
-     * @param newFileContent the content of the newly generated Java file
-     * @param existingFileContent the content of the existing Java file
-     * @return the merged source, properly formatted
-     * @throws MergeException if the file cannot be merged for some reason
-     */
     @Override
-    public String getMergedSource(String newFileContent, String existingFileContent) throws MergeException {
-        ParserConfiguration parserConfiguration = new ParserConfiguration();
-        parserConfiguration.setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_25);
-        if (isLexicalPreserving) {
-            parserConfiguration.setLexicalPreservationEnabled(true);
-        }
-        JavaParser javaParser = new JavaParser(parserConfiguration);
-
-        ParseResults existingFileParseResults = JavaMergeUtilities.parseAndFindMainTypeDeclaration(javaParser,
-                existingFileContent, MergeFileType.EXISTING_FILE);
-
-        // Gather custom members from the existing file. If none, just return the new file as is
-        CustomMemberGatherer customMemberGatherer =
-                new CustomMemberGatherer(existingFileParseResults.typeDeclaration());
-        if (!customMemberGatherer.hasAnyMembersToMerge()) {
-            return newFileContent;
-        }
-
-        // Custom members exist, need to merge...
-        ParseResults newFileParseResults = JavaMergeUtilities.parseAndFindMainTypeDeclaration(javaParser,
-                newFileContent, MergeFileType.NEW_FILE);
+    public String performMerge(CustomMemberGatherer customMemberGatherer, ParseResults existingFileParseResults,
+                               ParseResults newFileParseResults) {
+        TypeDeclaration<?> existingType = existingFileParseResults.typeDeclaration();
+        TypeDeclaration<?> newType = newFileParseResults.typeDeclaration();
 
         // Delete elements in the new file that match doNotDeleteMembers from the existing file
         customMemberGatherer.doNotDeleteBodyMembers()
-                .forEach(m -> JavaMergeUtilities
-                        .deleteDuplicateMemberIfExists(newFileParseResults.typeDeclaration(), m));
+                .forEach(m -> JavaMergeUtilities.deleteDuplicateMemberIfExists(newType, m));
 
         // Look for custom imports in the existing file and merge into the new file
         JavaMergeUtilities
@@ -121,19 +90,16 @@ public class MergeIntoNewJavaFileMerger implements JavaFileMerger {
                 .forEach(newFileParseResults.compilationUnit()::addImport);
 
         // Add custom body members from the existing file to the new file
-        customMemberGatherer.allCustomBodyMembers().forEach(newFileParseResults.typeDeclaration()::addMember);
+        customMemberGatherer.allCustomBodyMembers().forEach(newType::addMember);
 
         // Add custom enum constants from the existing file to the new file
-        if (newFileParseResults.typeDeclaration().isEnumDeclaration()) {
-            customMemberGatherer.customEnumConstants()
-                    .forEach(newFileParseResults.typeDeclaration().asEnumDeclaration()::addEntry);
+        if (newType.isEnumDeclaration()) {
+            customMemberGatherer.customEnumConstants().forEach(newType.asEnumDeclaration()::addEntry);
         }
 
         // Look for custom super interfaces in the existing file and merge into the new file
-        JavaMergeUtilities
-                .findCustomSuperInterfaces(existingFileParseResults.typeDeclaration(),
-                        newFileParseResults.typeDeclaration())
-                .forEach(t -> JavaMergeUtilities.addSuperInterface(newFileParseResults.typeDeclaration(), t));
+        JavaMergeUtilities.findCustomSuperInterfaces(existingType, newType)
+                .forEach(t -> JavaMergeUtilities.addSuperInterface(newType, t));
 
         // Return the new (merged) file
         return printer.print(newFileParseResults.compilationUnit());

--- a/core/mybatis-generator-core/src/test/java/org/mybatis/generator/merge/java/GenerateAndMergeTest.java
+++ b/core/mybatis-generator-core/src/test/java/org/mybatis/generator/merge/java/GenerateAndMergeTest.java
@@ -1,3 +1,18 @@
+/*
+ *    Copyright 2006-2026 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.mybatis.generator.merge.java;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -261,12 +276,12 @@ class GenerateAndMergeTest {
         String content = Files.readString(modelDirectory.resolve("test/model/Pkonly.kt"));
         assertThat(content).isEqualToNormalizingNewlines("""
             package test.model
-            
+
             import java.util.stream.IntStream
-            
+
             class Pkonly {
                 private val existingId: Int = 0
-            
+
                 fun getSum(): Int {
                     return IntStream.range(0, 100).filter { i -> i % 2 == 0 }.map { i -> i * 3 }.sum()
                 }
@@ -390,12 +405,12 @@ class GenerateAndMergeTest {
     private void writeExistingKotlinFile(Path modelDirectory) throws IOException {
         String content = """
                 package test.model
-                
+
                 import java.util.stream.IntStream
-                
+
                 class Pkonly {
                     private val existingId: Int = 0
-                
+
                     fun getSum(): Int {
                         return IntStream.range(0, 100).filter { i -> i % 2 == 0 }.map { i -> i * 3 }.sum()
                     }

--- a/core/mybatis-generator-core/src/test/java/org/mybatis/generator/merge/java/GenerateAndMergeTest.java
+++ b/core/mybatis-generator-core/src/test/java/org/mybatis/generator/merge/java/GenerateAndMergeTest.java
@@ -1,0 +1,415 @@
+package org.mybatis.generator.merge.java;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.mybatis.generator.SqlScriptRunner;
+import org.mybatis.generator.api.Indenter;
+import org.mybatis.generator.api.KnownRuntime;
+import org.mybatis.generator.api.MyBatisGenerator;
+import org.mybatis.generator.api.dom.DefaultJavaFormatter;
+import org.mybatis.generator.api.dom.java.Field;
+import org.mybatis.generator.api.dom.java.FullyQualifiedJavaType;
+import org.mybatis.generator.api.dom.java.JavaVisibility;
+import org.mybatis.generator.api.dom.java.Method;
+import org.mybatis.generator.api.dom.java.TopLevelClass;
+import org.mybatis.generator.config.ClientGeneratorConfiguration;
+import org.mybatis.generator.config.CommentGeneratorConfiguration;
+import org.mybatis.generator.config.Configuration;
+import org.mybatis.generator.config.Context;
+import org.mybatis.generator.config.JDBCConnectionConfiguration;
+import org.mybatis.generator.config.ModelGeneratorConfiguration;
+import org.mybatis.generator.config.ModelType;
+import org.mybatis.generator.config.Property;
+import org.mybatis.generator.config.SqlMapGeneratorConfiguration;
+import org.mybatis.generator.config.TableConfiguration;
+
+class GenerateAndMergeTest {
+    private static final String DRIVER_CLASS = "org.hsqldb.jdbcDriver";
+    public static final String JDBC_URL = "jdbc:hsqldb:mem:aname";
+
+    @Test
+    void shouldMergeJavaFiles() throws Exception {
+        Path modelDirectory = Files.createTempDirectory("model");
+
+        createDatabase();
+
+        writeExistingJavaFile(modelDirectory);
+
+        MyBatisGenerator myBatisGenerator = new MyBatisGenerator.Builder()
+                .withConfiguration(configuration(modelDirectory))
+                .withOverwriteEnabled(false)
+                .withJavaFileMergeEnabled(true)
+                .withContextIds(Set.of("test-context"))
+                .withFullyQualifiedTableNames(Set.of("PKONLY"))
+                .build();
+        List<String> warnings = myBatisGenerator.generateAndWrite();
+        assertThat(warnings).isEmpty();
+        String content = Files.readString(modelDirectory.resolve("test/model/Pkonly.java"));
+        assertThat(content).isEqualToNormalizingNewlines("""
+            package test.model;
+
+            import java.util.stream.IntStream;
+
+            import jakarta.annotation.Generated;
+
+            public class Pkonly {
+
+                private int existingId;
+
+                public int getSum() {
+                    return IntStream.range(0, 100)
+                                    .filter(i -> i % 2 == 0)
+                                    .map(i -> i * 3)
+                                    .sum();
+                }
+
+                @Generated("org.mybatis.generator.api.MyBatisGenerator")
+                private Integer id;
+
+                @Generated("org.mybatis.generator.api.MyBatisGenerator")
+                private Integer seqNum;
+
+                @Generated("org.mybatis.generator.api.MyBatisGenerator")
+                public Integer getId() {
+                    return id;
+                }
+
+                @Generated("org.mybatis.generator.api.MyBatisGenerator")
+                public void setId(Integer id) {
+                    this.id = id;
+                }
+
+                @Generated("org.mybatis.generator.api.MyBatisGenerator")
+                public Integer getSeqNum() {
+                    return seqNum;
+                }
+
+                @Generated("org.mybatis.generator.api.MyBatisGenerator")
+                public void setSeqNum(Integer seqNum) {
+                    this.seqNum = seqNum;
+                }
+            }
+            """);
+    }
+
+    @Test
+    void shouldOverwriteJavaFiles() throws Exception {
+        Path modelDirectory = Files.createTempDirectory("model");
+
+        createDatabase();
+
+        writeExistingJavaFile(modelDirectory);
+
+        MyBatisGenerator myBatisGenerator = new MyBatisGenerator.Builder()
+                .withConfiguration(configuration(modelDirectory))
+                .withOverwriteEnabled(true)
+                .withJavaFileMergeEnabled(false)
+                .build();
+        List<String> warnings = myBatisGenerator.generateAndWrite();
+        assertThat(warnings).hasSize(1);
+        String content = Files.readString(modelDirectory.resolve("test/model/Pkonly.java"));
+        assertThat(content).isEqualToNormalizingNewlines("""
+            package test.model;
+
+            import jakarta.annotation.Generated;
+
+            public class Pkonly {
+                @Generated("org.mybatis.generator.api.MyBatisGenerator")
+                private Integer id;
+
+                @Generated("org.mybatis.generator.api.MyBatisGenerator")
+                private Integer seqNum;
+
+                @Generated("org.mybatis.generator.api.MyBatisGenerator")
+                public Integer getId() {
+                    return id;
+                }
+
+                @Generated("org.mybatis.generator.api.MyBatisGenerator")
+                public void setId(Integer id) {
+                    this.id = id;
+                }
+
+                @Generated("org.mybatis.generator.api.MyBatisGenerator")
+                public Integer getSeqNum() {
+                    return seqNum;
+                }
+
+                @Generated("org.mybatis.generator.api.MyBatisGenerator")
+                public void setSeqNum(Integer seqNum) {
+                    this.seqNum = seqNum;
+                }
+            }""");
+
+    }
+
+    @Test
+    void shouldWriteNewVersionOfJavaFiles() throws Exception {
+        Path modelDirectory = Files.createTempDirectory("model");
+
+        createDatabase();
+
+        writeExistingJavaFile(modelDirectory);
+
+        MyBatisGenerator myBatisGenerator = new MyBatisGenerator.Builder()
+                .withConfiguration(configuration(modelDirectory))
+                .withOverwriteEnabled(false)
+                .withJavaFileMergeEnabled(false)
+                .build();
+        List<String> warnings = myBatisGenerator.generateAndWrite();
+        assertThat(warnings).hasSize(1);
+
+        String content = Files.readString(modelDirectory.resolve("test/model/Pkonly.java"));
+        assertThat(content).isEqualToNormalizingNewlines("""
+            package test.model;
+
+            import java.util.stream.IntStream;
+
+            public class Pkonly {
+                private int existingId;
+
+                public int getSum() {
+                    return IntStream.range(0, 100).filter(i -> i % 2 == 0).map(i -> i * 3).sum();
+                }
+            }""");
+
+        content = Files.readString(modelDirectory.resolve("test/model/Pkonly.java.1"));
+        assertThat(content).isEqualToNormalizingNewlines("""
+            package test.model;
+
+            import jakarta.annotation.Generated;
+
+            public class Pkonly {
+                @Generated("org.mybatis.generator.api.MyBatisGenerator")
+                private Integer id;
+
+                @Generated("org.mybatis.generator.api.MyBatisGenerator")
+                private Integer seqNum;
+
+                @Generated("org.mybatis.generator.api.MyBatisGenerator")
+                public Integer getId() {
+                    return id;
+                }
+
+                @Generated("org.mybatis.generator.api.MyBatisGenerator")
+                public void setId(Integer id) {
+                    this.id = id;
+                }
+
+                @Generated("org.mybatis.generator.api.MyBatisGenerator")
+                public Integer getSeqNum() {
+                    return seqNum;
+                }
+
+                @Generated("org.mybatis.generator.api.MyBatisGenerator")
+                public void setSeqNum(Integer seqNum) {
+                    this.seqNum = seqNum;
+                }
+            }""");
+    }
+
+    @Test
+    void shouldOverwriteKotlinFiles() throws Exception {
+        Path modelDirectory = Files.createTempDirectory("model");
+
+        createDatabase();
+
+        writeExistingKotlinFile(modelDirectory);
+
+        MyBatisGenerator myBatisGenerator = new MyBatisGenerator.Builder()
+                .withConfiguration(kotlinConfiguration(modelDirectory))
+                .withOverwriteEnabled(true)
+                .build();
+        List<String> warnings = myBatisGenerator.generateAndWrite();
+        assertThat(warnings).hasSize(1);
+        String content = Files.readString(modelDirectory.resolve("test/model/Pkonly.kt"));
+        assertThat(content).isEqualToNormalizingNewlines("""
+            /*
+             * Auto-generated file. Created by MyBatis Generator
+             */
+            package test.model
+
+            data class Pkonly(
+                val id: Int,
+                val seqNum: Int
+            )""");
+    }
+
+    @Test
+    void shouldWriteNewVersionOfKotlinFiles() throws Exception {
+        Path modelDirectory = Files.createTempDirectory("model");
+
+        createDatabase();
+
+        writeExistingKotlinFile(modelDirectory);
+
+        MyBatisGenerator myBatisGenerator = new MyBatisGenerator.Builder()
+                .withConfiguration(kotlinConfiguration(modelDirectory))
+                .withOverwriteEnabled(false)
+                .build();
+        List<String> warnings = myBatisGenerator.generateAndWrite();
+        assertThat(warnings).hasSize(1);
+
+        String content = Files.readString(modelDirectory.resolve("test/model/Pkonly.kt"));
+        assertThat(content).isEqualToNormalizingNewlines("""
+            package test.model
+            
+            import java.util.stream.IntStream
+            
+            class Pkonly {
+                private val existingId: Int = 0
+            
+                fun getSum(): Int {
+                    return IntStream.range(0, 100).filter { i -> i % 2 == 0 }.map { i -> i * 3 }.sum()
+                }
+            }
+            """);
+
+        content = Files.readString(modelDirectory.resolve("test/model/Pkonly.kt.1"));
+        assertThat(content).isEqualToNormalizingNewlines("""
+            /*
+             * Auto-generated file. Created by MyBatis Generator
+             */
+            package test.model
+
+            data class Pkonly(
+                val id: Int,
+                val seqNum: Int
+            )""");
+    }
+
+    private Configuration configuration(Path modelDirectory) throws IOException {
+        return new Configuration.Builder()
+                .withContext(context(modelDirectory))
+                .build();
+    }
+
+    private Context context(Path modelDirectory) throws IOException {
+        Path mapperDirectory = Files.createTempDirectory("mapper");
+        Path xmlDirectory = Files.createTempDirectory("xml");
+
+        return new Context.Builder()
+                .withId("test-context")
+                .withDefaultModelType(ModelType.FLAT)
+                .withTargetRuntime(KnownRuntime.MYBATIS3.getAlias())
+                .withJdbcConnectionConfiguration(new JDBCConnectionConfiguration.Builder()
+                        .withDriverClass(DRIVER_CLASS)
+                        .withConnectionURL(JDBC_URL)
+                        .withUserId("sa")
+                        .build())
+                .withModelGeneratorConfiguration(new ModelGeneratorConfiguration.Builder()
+                        .withTargetPackage("test.model")
+                        .withTargetProject(modelDirectory.toAbsolutePath().toString())
+                        .build())
+                .withClientGeneratorConfiguration(new ClientGeneratorConfiguration.Builder()
+                        .withLegacyClientType(ClientGeneratorConfiguration.LegacyClientType.XML_MAPPER)
+                        .withTargetPackage("test.mapper")
+                        .withTargetProject(mapperDirectory.toAbsolutePath().toString())
+                        .build())
+                .withSqlMapGeneratorConfiguration(new SqlMapGeneratorConfiguration.Builder()
+                        .withTargetPackage("test.xml")
+                        .withTargetProject(xmlDirectory.toAbsolutePath().toString())
+                        .build())
+                .withCommentGeneratorConfiguration(new CommentGeneratorConfiguration.Builder()
+                        .withProperty(new Property("minimizeComments", "true"))
+                        .build())
+                .withTableConfiguration(new TableConfiguration.Builder()
+                        .withTableName("PKONLY")
+                        .build())
+                .build();
+    }
+
+    private Configuration kotlinConfiguration(Path modelDirectory) throws IOException {
+        return new Configuration.Builder()
+                .withContext(kotlinContext(modelDirectory))
+                .build();
+    }
+
+    private Context kotlinContext(Path modelDirectory) throws IOException {
+        Path mapperDirectory = Files.createTempDirectory("mapper");
+
+        return new Context.Builder()
+                .withId("kotlin-context")
+                .withDefaultModelType(ModelType.FLAT)
+                .withTargetRuntime(KnownRuntime.MYBATIS3_KOTLIN.getAlias())
+                .withJdbcConnectionConfiguration(new JDBCConnectionConfiguration.Builder()
+                        .withDriverClass(DRIVER_CLASS)
+                        .withConnectionURL(JDBC_URL)
+                        .withUserId("sa")
+                        .build())
+                .withModelGeneratorConfiguration(new ModelGeneratorConfiguration.Builder()
+                        .withTargetPackage("test.model")
+                        .withTargetProject(modelDirectory.toAbsolutePath().toString())
+                        .build())
+                .withClientGeneratorConfiguration(new ClientGeneratorConfiguration.Builder()
+                        .withLegacyClientType(ClientGeneratorConfiguration.LegacyClientType.XML_MAPPER)
+                        .withTargetPackage("test.mapper")
+                        .withTargetProject(mapperDirectory.toAbsolutePath().toString())
+                        .build())
+                .withCommentGeneratorConfiguration(new CommentGeneratorConfiguration.Builder()
+                        .withProperty(new Property("minimizeComments", "true"))
+                        .build())
+                .withTableConfiguration(new TableConfiguration.Builder()
+                        .withTableName("PKONLY")
+                        .build())
+                .build();
+    }
+
+    private void writeExistingJavaFile(Path modelDirectory) throws IOException {
+        TopLevelClass topLevelClass = new TopLevelClass("test.model.Pkonly");
+        topLevelClass.setVisibility(JavaVisibility.PUBLIC);
+
+        Field field = new Field("existingId", FullyQualifiedJavaType.getIntInstance());
+        field.setVisibility(JavaVisibility.PRIVATE);
+        topLevelClass.addField(field);
+
+        Method method = new Method("getSum");
+        method.setVisibility(JavaVisibility.PUBLIC);
+        method.setReturnType(FullyQualifiedJavaType.getIntInstance());
+        method.addBodyLine("return IntStream.range(0, 100).filter(i -> i % 2 == 0).map(i -> i * 3).sum();");
+        topLevelClass.addMethod(method);
+
+        topLevelClass.addImportedType("java.util.stream.IntStream");
+
+        DefaultJavaFormatter defaultJavaFormatter = new DefaultJavaFormatter();
+        defaultJavaFormatter.setIndenter(Indenter.defaultIndenter());
+        String content = defaultJavaFormatter.getFormattedContent(topLevelClass);
+        Files.createDirectories(modelDirectory.resolve("test/model"));
+        Path javaFile = modelDirectory.resolve("test/model/Pkonly.java");
+        Files.writeString(javaFile, content, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+    }
+
+    private void writeExistingKotlinFile(Path modelDirectory) throws IOException {
+        String content = """
+                package test.model
+                
+                import java.util.stream.IntStream
+                
+                class Pkonly {
+                    private val existingId: Int = 0
+                
+                    fun getSum(): Int {
+                        return IntStream.range(0, 100).filter { i -> i % 2 == 0 }.map { i -> i * 3 }.sum()
+                    }
+                }
+                """;
+        Files.createDirectories(modelDirectory.resolve("test/model"));
+        Path javaFile = modelDirectory.resolve("test/model/Pkonly.kt");
+        Files.writeString(javaFile, content, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+    }
+
+    static void createDatabase() throws Exception {
+        SqlScriptRunner scriptRunner =
+                new SqlScriptRunner(GenerateAndMergeTest.class.getResourceAsStream("/scripts/CreateDB.sql"),
+                        DRIVER_CLASS, JDBC_URL, "sa", "");
+        scriptRunner.executeScript();
+    }
+}


### PR DESCRIPTION
- Remove the idea of new vs. existing in the merge utilities - source vs. target is more appropriate now that we have two merge strategies
- Consolidate some copy/paste code into an abstract super class
- Make some utility methods more concise
- Add more test coverage
