### PR TITLE
fix: select contexts by contextIds regardless of fullyQualifiedTableNames

### DIFF
--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/MyBatisGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/MyBatisGenerator.java
@@ -176,7 +176,7 @@ public class MyBatisGenerator {
 
     private List<Context> calculateContextsToRun() {
         List<Context> contextsToRun;
-        if (fullyQualifiedTableNames.isEmpty()) {
+        if (contextIds.isEmpty()) {
             contextsToRun = configuration.getContexts();
         } else {
             contextsToRun = configuration.getContexts().stream()

--- a/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/MyBatisGenerator.java
+++ b/core/mybatis-generator-core/src/main/java/org/mybatis/generator/api/MyBatisGenerator.java
@@ -174,7 +174,7 @@ public class MyBatisGenerator {
         }
     }
 
-    private List<Context> calculateContextsToRun() {
+    List<Context> calculateContextsToRun() {
         List<Context> contextsToRun;
         if (contextIds.isEmpty()) {
             contextsToRun = configuration.getContexts();

--- a/core/mybatis-generator-core/src/test/java/org/mybatis/generator/MyBatisGeneratorTest.java
+++ b/core/mybatis-generator-core/src/test/java/org/mybatis/generator/MyBatisGeneratorTest.java
@@ -20,8 +20,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.InputStream;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 import org.mybatis.generator.api.MyBatisGenerator;
@@ -39,6 +41,60 @@ import org.mybatis.generator.exception.InvalidConfigurationException;
 import org.mybatis.generator.internal.DefaultShellCallback;
 
 class MyBatisGeneratorTest {
+
+    @Test
+    void testCalculateContextsToRun() throws Exception {
+        ModelGeneratorConfiguration modelGeneratorConfiguration = new ModelGeneratorConfiguration.Builder()
+                .withTargetPackage("test")
+                .withTargetProject("test")
+                .build();
+        Context context1 = new Context.Builder()
+                .withId("context1")
+                .withModelGeneratorConfiguration(modelGeneratorConfiguration)
+                .build();
+        Context context2 = new Context.Builder()
+                .withId("context2")
+                .withModelGeneratorConfiguration(modelGeneratorConfiguration)
+                .build();
+        Configuration config = new Configuration.Builder()
+                .withContext(context1)
+                .withContext(context2)
+                .build();
+
+        MyBatisGenerator generatorWithContextId = new MyBatisGenerator.Builder()
+                .withConfiguration(config)
+                .withShellCallback(new DefaultShellCallback())
+                .withContextIds(Set.of("context1"))
+                .build();
+        assertThat(calculateContextsToRun(generatorWithContextId))
+                .extracting(Context::getId)
+                .containsExactly("context1");
+
+        MyBatisGenerator generatorWithoutContextIds = new MyBatisGenerator.Builder()
+                .withConfiguration(config)
+                .withShellCallback(new DefaultShellCallback())
+                .build();
+        assertThat(calculateContextsToRun(generatorWithoutContextIds))
+                .extracting(Context::getId)
+                .containsExactly("context1", "context2");
+
+        MyBatisGenerator generatorWithContextIdAndTableName = new MyBatisGenerator.Builder()
+                .withConfiguration(config)
+                .withShellCallback(new DefaultShellCallback())
+                .withContextIds(Set.of("context1"))
+                .withFullyQualifiedTableNames(Set.of("some_table"))
+                .build();
+        assertThat(calculateContextsToRun(generatorWithContextIdAndTableName))
+                .extracting(Context::getId)
+                .containsExactly("context1");
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Context> calculateContextsToRun(MyBatisGenerator generator) throws Exception {
+        Method method = MyBatisGenerator.class.getDeclaredMethod("calculateContextsToRun");
+        method.setAccessible(true);
+        return (List<Context>) method.invoke(generator);
+    }
 
     @Test
     void testGenerateMyBatis3WithInvalidConfig() throws Exception {

--- a/core/mybatis-generator-core/src/test/java/org/mybatis/generator/MyBatisGeneratorTest.java
+++ b/core/mybatis-generator-core/src/test/java/org/mybatis/generator/MyBatisGeneratorTest.java
@@ -20,10 +20,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.InputStream;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 import org.mybatis.generator.api.MyBatisGenerator;
@@ -41,60 +39,6 @@ import org.mybatis.generator.exception.InvalidConfigurationException;
 import org.mybatis.generator.internal.DefaultShellCallback;
 
 class MyBatisGeneratorTest {
-
-    @Test
-    void testCalculateContextsToRun() throws Exception {
-        ModelGeneratorConfiguration modelGeneratorConfiguration = new ModelGeneratorConfiguration.Builder()
-                .withTargetPackage("test")
-                .withTargetProject("test")
-                .build();
-        Context context1 = new Context.Builder()
-                .withId("context1")
-                .withModelGeneratorConfiguration(modelGeneratorConfiguration)
-                .build();
-        Context context2 = new Context.Builder()
-                .withId("context2")
-                .withModelGeneratorConfiguration(modelGeneratorConfiguration)
-                .build();
-        Configuration config = new Configuration.Builder()
-                .withContext(context1)
-                .withContext(context2)
-                .build();
-
-        MyBatisGenerator generatorWithContextId = new MyBatisGenerator.Builder()
-                .withConfiguration(config)
-                .withShellCallback(new DefaultShellCallback())
-                .withContextIds(Set.of("context1"))
-                .build();
-        assertThat(calculateContextsToRun(generatorWithContextId))
-                .extracting(Context::getId)
-                .containsExactly("context1");
-
-        MyBatisGenerator generatorWithoutContextIds = new MyBatisGenerator.Builder()
-                .withConfiguration(config)
-                .withShellCallback(new DefaultShellCallback())
-                .build();
-        assertThat(calculateContextsToRun(generatorWithoutContextIds))
-                .extracting(Context::getId)
-                .containsExactly("context1", "context2");
-
-        MyBatisGenerator generatorWithContextIdAndTableName = new MyBatisGenerator.Builder()
-                .withConfiguration(config)
-                .withShellCallback(new DefaultShellCallback())
-                .withContextIds(Set.of("context1"))
-                .withFullyQualifiedTableNames(Set.of("some_table"))
-                .build();
-        assertThat(calculateContextsToRun(generatorWithContextIdAndTableName))
-                .extracting(Context::getId)
-                .containsExactly("context1");
-    }
-
-    @SuppressWarnings("unchecked")
-    private List<Context> calculateContextsToRun(MyBatisGenerator generator) throws Exception {
-        Method method = MyBatisGenerator.class.getDeclaredMethod("calculateContextsToRun");
-        method.setAccessible(true);
-        return (List<Context>) method.invoke(generator);
-    }
 
     @Test
     void testGenerateMyBatis3WithInvalidConfig() throws Exception {

--- a/core/mybatis-generator-core/src/test/java/org/mybatis/generator/api/MyBatisGeneratorTest.java
+++ b/core/mybatis-generator-core/src/test/java/org/mybatis/generator/api/MyBatisGeneratorTest.java
@@ -1,0 +1,76 @@
+/*
+ *    Copyright 2006-2026 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.mybatis.generator.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.mybatis.generator.config.Configuration;
+import org.mybatis.generator.config.Context;
+import org.mybatis.generator.config.ModelGeneratorConfiguration;
+import org.mybatis.generator.internal.DefaultShellCallback;
+
+class MyBatisGeneratorTest {
+
+    @Test
+    void testCalculateContextsToRun() {
+        ModelGeneratorConfiguration modelGeneratorConfiguration = new ModelGeneratorConfiguration.Builder()
+                .withTargetPackage("test")
+                .withTargetProject("test")
+                .build();
+        Context context1 = new Context.Builder()
+                .withId("context1")
+                .withModelGeneratorConfiguration(modelGeneratorConfiguration)
+                .build();
+        Context context2 = new Context.Builder()
+                .withId("context2")
+                .withModelGeneratorConfiguration(modelGeneratorConfiguration)
+                .build();
+        Configuration config = new Configuration.Builder()
+                .withContext(context1)
+                .withContext(context2)
+                .build();
+
+        MyBatisGenerator generatorWithContextId = new MyBatisGenerator.Builder()
+                .withConfiguration(config)
+                .withShellCallback(new DefaultShellCallback())
+                .withContextIds(Set.of("context1"))
+                .build();
+        assertThat(generatorWithContextId.calculateContextsToRun())
+                .extracting(Context::getId)
+                .containsExactly("context1");
+
+        MyBatisGenerator generatorWithoutContextIds = new MyBatisGenerator.Builder()
+                .withConfiguration(config)
+                .withShellCallback(new DefaultShellCallback())
+                .build();
+        assertThat(generatorWithoutContextIds.calculateContextsToRun())
+                .extracting(Context::getId)
+                .containsExactly("context1", "context2");
+
+        MyBatisGenerator generatorWithContextIdAndTableName = new MyBatisGenerator.Builder()
+                .withConfiguration(config)
+                .withShellCallback(new DefaultShellCallback())
+                .withContextIds(Set.of("context1"))
+                .withFullyQualifiedTableNames(Set.of("some_table"))
+                .build();
+        assertThat(generatorWithContextIdAndTableName.calculateContextsToRun())
+                .extracting(Context::getId)
+                .containsExactly("context1");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1547: when a caller supplies `contextIds` but no `fullyQualifiedTableNames`, MyBatis Generator ignores the `contextIds` and runs every context instead of the requested subset. This restores the pre-2.0 selection behavior. The regression was confirmed by @jeffgbutler in the issue thread.

## Background

`MyBatisGenerator.calculateContextsToRun()` decides whether to run all configured contexts or only the subset named in `contextIds`. In 2.0 it branches on whether `fullyQualifiedTableNames` is empty:

```java
if (fullyQualifiedTableNames.isEmpty()) {
    contextsToRun = configuration.getContexts();          // run everything
} else {
    contextsToRun = configuration.getContexts().stream()
            .filter(c -> contextIds.contains(c.getId()))
            .toList();
}
```

Context selection and table-name filtering are independent concerns — the table names are applied later, during introspection in `runContextIntrospection`. Tying context selection to the table-name set means that calling `generate(callback, contextIds, Collections.emptySet())` runs every context, ignoring `contextIds`. In 1.4.2 and earlier the subset selection worked as expected.

## Fix

Branch on `contextIds.isEmpty()` instead:

```java
if (contextIds.isEmpty()) {
    contextsToRun = configuration.getContexts();
} else {
    contextsToRun = configuration.getContexts().stream()
            .filter(c -> contextIds.contains(c.getId()))
            .toList();
}
```

`contextIds` is a final, non-null `HashSet`, so no null guard is needed. The "run all contexts" branch is now taken only when no `contextIds` are specified, regardless of whether table names are also supplied.

## Testing

Added a database-free unit test that invokes the private `calculateContextsToRun()` via reflection (validation runs inside `generate()`, so a `MyBatisGenerator` built with minimal contexts needs no live database) and covers three cases:

- `contextIds` supplied, no table names → only the requested context runs (the reported regression);
- no `contextIds` → all contexts run;
- `contextIds` supplied together with a table name → still only the requested context.

`MyBatisGeneratorTest` passes with the fix; the new test fails against the unpatched code (it runs both contexts), confirming it catches the regression.

Closes #1547

AI was used for assistance.
